### PR TITLE
Fix a small bug on "Validate FEN" button

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -925,7 +925,7 @@ function validateFEN(FEN) {
   if (FEN == null) {
     return false;
   }
-  let result = ffish.validateFen(FEN);
+  let result = ffish.validateFen(FEN, dropdownVariant.value);
   if (result >= 0) {
     window.alert("No errors found.");
     return true;


### PR DESCRIPTION
The Validate FEN button can only check FEN of chess currently. After this change, ffish.js will check FEN according to the given variant.