### PR TITLE
Binary Engine Loading Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ npm run watch-build
 Start server
 
 ```bash
+#Static website
 npm run serve
+
+#Enable binary engine loading feature
+node server.js
 ```
 
-Then, browse to http://localhost:5000
+Then, browse to http://localhost:5000 (Static website) or http://localhost:5015 (Enable binary engine loading feature)
 
 Enjoy!
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "serve": "serve public --no-compression",
-    "build": "rm -rf public/lib && mkdir -p public/lib && cp node_modules/fairy-stockfish-nnue.wasm/* public/lib && cp node_modules/ffish-es6/ffish.wasm public/ && browserify -p esmify src/main.js -o public/bundle.js && cp node_modules/mithril/mithril.min.js public/lib",
-    "buildwithcmd": "rd /s /q public\\lib & md public\\lib && copy /Y node_modules\\fairy-stockfish-nnue.wasm\\* public\\lib && copy /Y node_modules\\ffish-es6\\ffish.wasm public\\ && browserify -p esmify src/main.js -o public/bundle.js && copy /Y node_modules\\mithril\\mithril.min.js public\\lib",
+    "build": "rm -rf public/lib && mkdir -p public/lib && cp node_modules/fairy-stockfish-nnue.wasm/* public/lib && cp node_modules/ffish-es6/ffish.wasm public/ && browserify -p esmify src/main.js -o public/bundle.js && cp node_modules/mithril/mithril.min.js public/lib && cp src/BinaryEngineFeature.js public/lib && cp -f src/server.js .",
+    "buildwithcmd": "rd /s /q public\\lib & md public\\lib && copy /Y node_modules\\fairy-stockfish-nnue.wasm\\* public\\lib && copy /Y node_modules\\ffish-es6\\ffish.wasm public\\ && browserify -p esmify src/main.js -o public/bundle.js && copy /Y node_modules\\mithril\\mithril.min.js public\\lib && copy /Y src\\BinaryEngineFeature.js public\\lib\\ && copy /Y src\\server.js .\\",
     "watch-build": "watchify -p esmify src/main.js -o public/bundle.js",
     "format": "prettier --write src public/*.html",
     "format:check": "prettier --check src public/*.html"
@@ -14,14 +14,15 @@
     "fairy-stockfish-nnue.wasm": "^1.1.5",
     "ffish-es6": "^0.7.5",
     "mithril": "^2.2.2",
-    "serve": "^14.2.1"
+    "serve": "^14.2.1",
+    "ws": "^8.16.0"
   },
   "devDependencies": {
     "browser-resolve": "^2.0.0",
     "browserify": "^17.0.0",
     "esmify": "^2.1.1",
     "prettier": "^3.2.5",
-    "watchify": "^4.0.0",
-    "vercel": "^33.5.2"
+    "vercel": "^33.5.2",
+    "watchify": "^4.0.0"
   }
 }

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1894,7 +1894,7 @@
 
       const setVariant = () => {
         play_move = false;
-        force_stop();
+        stop(true);
         const variant = $("#dropdown-variant").value;
         stockfish.postMessage(`setoption name UCI_Variant value ${variant}`);
         stockfish.postMessage(`position startpos`);
@@ -2403,7 +2403,7 @@
       const displayCurrentPosition = () => {
         $("#gotomovenum").value = totalMoveNumber();
         console.log(`Current: ${!during_play}`);
-        displayMove(-1, !during_play);
+        displayMove(-1, false);
       };
 
       const displaySpecifiedPosition = () => {
@@ -4302,6 +4302,7 @@
                     return;
                   }
                   play_move = false;
+                  //console.log(Error());
                   window.setTimeout(() => {
                     setFen(false, true);
                   }, 10);

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1746,7 +1746,7 @@
             );
 
             fge.ws.addEventListener("open", function (event) {
-              fge.ws.send(`CONNECT|${checkconnectionnumber}`);
+              fge.ws.send(`CONNECT\x10${checkconnectionnumber}`);
             });
 
             fge.ws.addEventListener("message", function (event) {

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -319,6 +319,56 @@
     margin-bottom: 10px;
   }
 
+  #binengineinput {
+    margin-bottom: 5px;
+  }
+
+  #binengineinput button {
+    display: inline-block;
+    padding: 3px 6px 3px 6px;
+    background: #888;
+    color: #fff;
+    font-weight: bold;
+    margin-right: 5px;
+    cursor: pointer;
+    margin-bottom: 5px;
+  }
+
+  #binengineinput button:hover {
+    background: #aaa;
+  }
+
+  #binengineinput button:disabled {
+    background: #ccc;
+    color: #000;
+  }
+
+  #binengineinput button:active {
+    background: #000;
+  }
+
+  #binengineinput input {
+    padding: 2px 0 2px 6px;
+    border: 1px solid #ddd;
+  }
+
+  #binengineinput input:invalid {
+    background: #ff9e9e;
+    border: 3px solid #f00;
+  }
+
+  #binengineinput #whiteenginesettings {
+    display: flex;
+  }
+
+  #binengineinput #blackenginesettings {
+    display: flex;
+  }
+
+  #binengineinput #analysisenginesettings {
+    display: flex;
+  }
+
   #posvariantdiv {
     display: flex;
     margin-bottom: 10px;
@@ -498,7 +548,7 @@
   }
 
   #info #enginecmddiv #enginecmd {
-    width: 600px;
+    width: 500px;
     padding: 2px 0 2px 6px;
     border: 1px solid #ddd;
   }
@@ -524,6 +574,11 @@
 
   #info #enginecmddiv #sendenginecmd:active {
     background: #000;
+  }
+
+  #info #enginecmddiv #targetengine {
+    width: 200px;
+    background: #eee;
   }
 
   #blacktime {
@@ -951,10 +1006,168 @@
   #separatorsearchresult {
     border: double #ffffff;
   }
+
+  #enginesettingspopup {
+    display: none;
+    position: fixed;
+    top: 0%;
+    left: 0%;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    background-color: white;
+    border-radius: 5px;
+    overflow: scroll;
+  }
+
+  #enginesettingspopup button {
+    display: inline-block;
+    padding: 3px 6px 3px 6px;
+    background: #888;
+    color: #fff;
+    font-weight: bold;
+    margin-left: 6px;
+    margin-right: 6px;
+    cursor: pointer;
+  }
+
+  #enginesettingspopup button:hover {
+    background: #aaa;
+  }
+
+  #enginesettingspopup button:disabled {
+    background: #ccc;
+    color: #000;
+  }
+
+  #enginesettingspopup button:active {
+    background: #000;
+  }
+
+  #enginesettingspopup input {
+    padding: 2px 0 2px 6px;
+    border: 1px solid #ddd;
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+
+  #enginesettingspopup select {
+    min-width: 120px;
+    background: #eee;
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+
+  #enginemanagementpopup {
+    display: none;
+    position: fixed;
+    top: 0%;
+    left: 0%;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    background-color: white;
+    border-radius: 5px;
+    overflow: scroll;
+  }
+
+  #enginemanagementpopup button {
+    display: inline-block;
+    padding: 3px 6px 3px 6px;
+    background: #888;
+    color: #fff;
+    font-weight: bold;
+    margin-left: 6px;
+    margin-right: 6px;
+    cursor: pointer;
+  }
+
+  #enginemanagementpopup button:hover {
+    background: #aaa;
+  }
+
+  #enginemanagementpopup button:disabled {
+    background: #ccc;
+    color: #000;
+  }
+
+  #enginemanagementpopup button:active {
+    background: #000;
+  }
+
+  #enginemanagementpopup input {
+    padding: 2px 0 2px 6px;
+    border: 1px solid #ddd;
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+
+  #enginemanagementpopup select {
+    min-width: 120px;
+    background: #eee;
+    margin-left: 6px;
+    margin-right: 6px;
+  }
+
+  #enginesetuppopup {
+    display: none;
+    position: fixed;
+    top: 0%;
+    left: 0%;
+    width: 100%;
+    height: 100%;
+    z-index: 2;
+    background-color: white;
+    border-radius: 5px;
+    overflow: scroll;
+  }
+
+  #enginesetuppopup button {
+    display: inline-block;
+    padding: 3px 6px 3px 6px;
+    background: #888;
+    color: #fff;
+    font-weight: bold;
+    margin-left: 6px;
+    margin-right: 6px;
+    cursor: pointer;
+  }
+
+  #enginesetuppopup button:hover {
+    background: #aaa;
+  }
+
+  #enginesetuppopup button:disabled {
+    background: #ccc;
+    color: #000;
+  }
+
+  #enginesetuppopup button:active {
+    background: #000;
+  }
+
+  #enginesetuppopup input {
+    padding: 2px 0 2px 6px;
+    border: 1px solid #ddd;
+    margin-left: 6px;
+    margin-right: 6px;
+    min-width: 300px;
+  }
+
+  #enginesetuppopup select {
+    min-width: 120px;
+    background: #eee;
+    margin-left: 6px;
+    margin-right: 6px;
+  }
 </style>
 
 <body>
   <div id="root"></div>
+  <script>
+    //Fairyground namespace for variable/function definition transfer
+    window.fairyground = { super: window };
+  </script>
   <script src="bundle.js" defer></script>
 
   <!--iframe src="./themes.html" onload="this.before((this.contentDocument.body || this.contentDocument).children[0]); this.remove();"--><!--/iframe-->
@@ -963,7 +1176,10 @@
 
   <script src="./lib/stockfish.js"></script>
   <script src="./lib/mithril.min.js"></script>
+  <script src="./lib/BinaryEngineFeature.js"></script>
   <script>
+    //For quick access (Shortening the name)
+    var fge = window.fairyground.BinaryEngineFeature;
     let themes = [[], [], []];
     let themenames = [[], []];
     let variantsettings = [[], [], [], []];
@@ -1152,7 +1368,7 @@
             variantsettings[2].push(variantdescriptionitem[2]);
             variantsettings[3].push(variantdescriptionitem[3]);
           }
-          console.log(variantsettings);
+          //console.log(variantsettings);
         } else {
           console.error(
             `Bad data type from variantsettings.txt: ${typeof data}`,
@@ -1453,6 +1669,9 @@
       let stockfish = null;
       let stockfish_state = "INIT"; // 'READY', 'FAILED'
       let output2 = "";
+      let first_engine_output = "";
+      let second_engine_output = "";
+      let analysis_engine_output = "";
       let show_dests = true;
       let adjudicate = true;
       let analysis_mode = false;
@@ -1464,6 +1683,8 @@
       let advanced_time_control = false;
       let during_play = false;
       let select_move_dialog = false;
+      let white_start_time = 0;
+      let black_start_time = 0;
       let white_remaining_time = 0;
       let black_remaining_time = 0;
       let white_moving_time_list = [];
@@ -1483,10 +1704,166 @@
       let black_time_margin = 0;
       let timeout_margin = 500;
       let previous_mover = "";
+      let move_finish_timer_updating = false;
+      let changing_variant_type = false;
       let timer;
 
       let variants = [];
       let varianttypes = [];
+
+      let engine_list = [];
+
+      const checkconnectionnumber = parseInt(Math.random() * 100000);
+      let wsport = window.location.port;
+      if (wsport == "") {
+        wsport = 5001;
+      } else {
+        wsport = +wsport + 1;
+      }
+
+      let i = 0;
+      if (window.location.hostname == "localhost") {
+        for (i = 0; i < fge.WebSocketReconnectionTime; i++) {
+          try {
+            fge.ws = new WebSocket(
+              "ws://" + window.location.hostname + ":" + wsport.toString(),
+            );
+
+            fge.ws.addEventListener("open", function (event) {
+              fge.ws.send(`CONNECT|${checkconnectionnumber}`);
+            });
+
+            fge.ws.addEventListener("message", function (event) {
+              if (typeof event.data != "string") {
+                console.error(
+                  `%c WebSocket %c ERROR %c Received bad data type from server: ${typeof event.data}`,
+                  "color: #fff; background: #5f5f5f",
+                  "color: #fff; background: #f03a17",
+                  "",
+                );
+                fge.ws.close();
+                fge.WebSocketStatus = "ERROR";
+                document.getElementById("binengineinput").hidden = true;
+                fge.first_engine = null;
+                fge.second_engine = null;
+                fge.analysis_engine = null;
+                return;
+              }
+              let msg = event.data.split("|");
+              if (fge.WebSocketStatus == "Unestablished") {
+                if (event.data == `${checkconnectionnumber}`) {
+                  console.log(
+                    `%c WebSocket %c CONNECTED %c WebSocket connection established.`,
+                    "color: #fff; background: #5f5f5f",
+                    "color: #fff; background: #4bc729",
+                    "",
+                  );
+                  fge.WebSocketStatus = "CONNECTED";
+                  fge.ws.send("READYOK");
+                  document.getElementById("binengineinput").hidden = false;
+                } else {
+                  console.error(
+                    `%c WebSocket %c ERROR %c WebSocket Server conncetion failed: Server returns bad verification code.`,
+                    "color: #fff; background: #5f5f5f",
+                    "color: #fff; background: #f03a17",
+                    "",
+                  );
+                  fge.ws.close();
+                  fge.WebSocketStatus = "ERROR";
+                  document.getElementById("binengineinput").hidden = true;
+                  fge.first_engine = null;
+                  fge.second_engine = null;
+                  fge.analysis_engine = null;
+                }
+              } else if (fge.WebSocketStatus == "CONNECTED") {
+                if (msg[0] == "UPDATE_DATA") {
+                  fge.GetEngineList((data) => {
+                    engine_list = data;
+                  }, fge.ws);
+                  console.log(engine_list);
+                }
+              }
+            });
+
+            fge.ws.addEventListener("close", function (event) {
+              let { code, reason, wasClen } = event;
+              if (fge.WebSocketStatus == "ERROR") {
+                return;
+              }
+              console.error(
+                `%c WebSocket %c CLOSED %c WebSocket Connection Closed.`,
+                "color: #fff; background: #5f5f5f",
+                "color: #fff; background: #f03a17",
+                "",
+              );
+              console.error(event);
+              fge.WebSocketStatus = "CLOSED";
+              document.getElementById("binengineinput").hidden = true;
+              fge.first_engine = null;
+              fge.second_engine = null;
+              fge.analysis_engine = null;
+              window.alert(
+                "WebSocket connection has closed. You will be unable to use binary engines. Try reloading this page to fix this.",
+              );
+            });
+
+            fge.ws.addEventListener("error", function (event) {
+              fge.WebSocketStatus = "ERROR";
+              console.error(
+                `%c WebSocket %c ERROR %c Errors occurred during establishing WebSocket connection.`,
+                "color: #fff; background: #5f5f5f",
+                "color: #fff; background: #f03a17",
+                "",
+              );
+              console.error(event);
+              document.getElementById("binengineinput").hidden = true;
+              fge.first_engine = null;
+              fge.second_engine = null;
+              fge.analysis_engine = null;
+            });
+
+            break;
+          } catch {
+            console.warn(
+              `%c WebSocket %c WARNING %c Cannot initiate WebSocket connection. Retrying... (${i + 1}/${fge.WebSocketReconnectionTime})`,
+              "color: #fff; background: #5f5f5f",
+              "color: #fff; background: #ffc83d",
+              "",
+            );
+            continue;
+          }
+        }
+        if (i == fge.WebSocketReconnectionTime) {
+          console.error(
+            `%c WebSocket %c ERROR %c Cannot initiate WebSocket connection. Binary engine loading feature will be disabled.`,
+            "color: #fff; background: #5f5f5f",
+            "color: #fff; background: #f03a17",
+            "",
+          );
+          fge.ws = null;
+          fge.WebSocketStatus = "ERROR";
+          window.alert(
+            "Cannot initiate WebSocket connection. Binary engine loading feature will be disabled.",
+          );
+          document.getElementById("binengineinput").hidden = true;
+          fge.first_engine = null;
+          fge.second_engine = null;
+          fge.analysis_engine = null;
+        }
+      } else {
+        console.error(
+          `%c WebSocket %c ERROR %c Cannot initiate WebSocket connection in online versions.`,
+          "color: #fff; background: #5f5f5f",
+          "color: #fff; background: #f03a17",
+          "",
+        );
+        fge.ws = null;
+        fge.WebSocketStatus = "ERROR";
+        document.getElementById("binengineinput").hidden = true;
+        fge.first_engine = null;
+        fge.second_engine = null;
+        fge.analysis_engine = null;
+      }
 
       const getVariants = () => {
         stockfish.postMessage(`uci`);
@@ -1494,10 +1871,35 @@
 
       const setVariant = () => {
         play_move = false;
-        stop();
+        force_stop();
         const variant = $("#dropdown-variant").value;
         stockfish.postMessage(`setoption name UCI_Variant value ${variant}`);
         stockfish.postMessage(`position startpos`);
+        if (fge.WebSocketStatus == "CONNECTED") {
+          if (fge.first_engine) {
+            if (fge.first_engine.SetVariant(variant)) {
+              document.getElementById("whiteunsupportedvariant").hidden = true;
+            } else {
+              document.getElementById("whiteunsupportedvariant").hidden = false;
+            }
+          }
+          if (fge.second_engine) {
+            if (fge.second_engine.SetVariant(variant)) {
+              document.getElementById("blackunsupportedvariant").hidden = true;
+            } else {
+              document.getElementById("blackunsupportedvariant").hidden = false;
+            }
+          }
+          if (fge.analysis_engine) {
+            if (fge.analysis_engine.SetVariant(variant)) {
+              document.getElementById("analysisunsupportedvariant").hidden =
+                true;
+            } else {
+              document.getElementById("analysisunsupportedvariant").hidden =
+                false;
+            }
+          }
+        }
         $("#fen").value = "";
         $("#move").value = "";
         resetTimer();
@@ -1505,10 +1907,13 @@
         setVariantStylesheet(variant);
       };
 
-      const setFen = () => {
-        stop();
-        const fen = $("#fen").value;
-        const moves = $("#move").value;
+      const setFen = (
+        interrupt_ponder,
+        automatically_start_engine_thinking,
+      ) => {
+        stop(interrupt_ponder);
+        const fen = $("#fen").value.trim();
+        const moves = $("#move").value.trim();
 
         if (fen.length > 0) {
           stockfish.postMessage(`position fen ${fen} moves ${moves}`);
@@ -1516,13 +1921,161 @@
           stockfish.postMessage(`position startpos moves ${moves}`);
         }
         const stm = $("#label-stm").innerText;
+        if (fge.WebSocketStatus == "CONNECTED") {
+          if (fge.analysis_engine) {
+            fge.analysis_engine.SetPosition(
+              fen,
+              moves,
+              fge.GetBoardWidth(),
+              fge.GetBoardHeight(),
+            );
+          }
+          if (
+            interrupt_ponder ||
+            !advanced_time_control ||
+            (advanced_time_control && !during_play)
+          ) {
+            if (fge.first_engine) {
+              fge.first_engine.SetPosition(
+                fen,
+                moves,
+                fge.GetBoardWidth(),
+                fge.GetBoardHeight(),
+              );
+            }
+            if (fge.second_engine) {
+              fge.second_engine.SetPosition(
+                fen,
+                moves,
+                fge.GetBoardWidth(),
+                fge.GetBoardHeight(),
+              );
+            }
+          } else {
+            if (stm == "white") {
+              if (fge.first_engine) {
+                if (fge.first_engine.Ponder) {
+                  if (
+                    fge.first_engine.PonderMove != "0000" &&
+                    fge.first_engine.PonderMove !=
+                      $("#move").value.trim().split(" ").at(-1)
+                  ) {
+                    fge.first_engine.SetPonderMiss();
+                    fge.first_engine.SetPosition(
+                      fen,
+                      moves,
+                      fge.GetBoardWidth(),
+                      fge.GetBoardHeight(),
+                    );
+                    console.log(
+                      `%c Ponder %c MISS %c WHITE Ponder misses`,
+                      "color: #fff; background: #5f5f5f",
+                      "color: #fff; background: #f03a17",
+                      "",
+                    );
+                  } else if (fge.first_engine.PonderMove == "0000") {
+                    fge.first_engine.SetPosition(
+                      fen,
+                      moves,
+                      fge.GetBoardWidth(),
+                      fge.GetBoardHeight(),
+                    );
+                  }
+                } else {
+                  fge.first_engine.SetPosition(
+                    fen,
+                    moves,
+                    fge.GetBoardWidth(),
+                    fge.GetBoardHeight(),
+                  );
+                }
+              }
+              if (fge.second_engine) {
+                if (fge.second_engine.Ponder) {
+                  fge.second_engine.SetPosition(
+                    fen,
+                    moves + ` ${fge.second_engine.PonderMove}`,
+                    fge.GetBoardWidth(),
+                    fge.GetBoardHeight(),
+                  );
+                } else {
+                  fge.second_engine.SetPosition(
+                    fen,
+                    moves,
+                    fge.GetBoardWidth(),
+                    fge.GetBoardHeight(),
+                  );
+                }
+              }
+            } else if (stm == "black") {
+              if (fge.second_engine) {
+                if (fge.second_engine.Ponder) {
+                  if (
+                    fge.second_engine.PonderMove != "0000" &&
+                    fge.second_engine.PonderMove !=
+                      $("#move").value.trim().split(" ").at(-1)
+                  ) {
+                    fge.second_engine.SetPonderMiss();
+                    fge.second_engine.SetPosition(
+                      fen,
+                      moves,
+                      fge.GetBoardWidth(),
+                      fge.GetBoardHeight(),
+                    );
+                    console.log(
+                      `%c Ponder %c MISS %c BLACK Ponder misses`,
+                      "color: #fff; background: #5f5f5f",
+                      "color: #fff; background: #f03a17",
+                      "",
+                    );
+                  } else if (fge.second_engine.PonderMove == "0000") {
+                    fge.second_engine.SetPosition(
+                      fen,
+                      moves,
+                      fge.GetBoardWidth(),
+                      fge.GetBoardHeight(),
+                    );
+                  }
+                } else {
+                  fge.second_engine.SetPosition(
+                    fen,
+                    moves,
+                    fge.GetBoardWidth(),
+                    fge.GetBoardHeight(),
+                  );
+                }
+              }
+              if (fge.first_engine) {
+                if (fge.first_engine.Ponder) {
+                  fge.first_engine.SetPosition(
+                    fen,
+                    moves + ` ${fge.first_engine.PonderMove}`,
+                    fge.GetBoardWidth(),
+                    fge.GetBoardHeight(),
+                  );
+                } else {
+                  fge.first_engine.SetPosition(
+                    fen,
+                    moves,
+                    fge.GetBoardWidth(),
+                    fge.GetBoardHeight(),
+                  );
+                }
+              }
+            }
+          }
+        }
+        updateTimerOnMove();
+
         if (
+          automatically_start_engine_thinking &&
           stm != "undefined" &&
-          (analysis_mode ||
-            (play_white && stm == "white") ||
-            (play_black && stm == "black"))
-        )
+          ((play_white && stm == "white") ||
+            (play_black && stm == "black") ||
+            analysis_mode)
+        ) {
           setTimeout(go(), 10);
+        }
       };
 
       const sendCommandToEngine = () => {
@@ -1586,17 +2139,9 @@
         if (
           cmd[0] == "setoption" &&
           cmd[1] == "name" &&
-          cmd[2] == "SyzygyPath"
-        ) {
-          window.alert(
-            "Cannot send this command: Syzygy tablebase files cannot be accessed by setting value here, as the engine is running in WASM binary in the browser and web browsers do not allow accessing client's files without consent.",
-          );
-          return;
-        }
-        if (
-          cmd[0] == "setoption" &&
-          cmd[1] == "name" &&
-          cmd[2] == "UCI_Variant"
+          (cmd[2] == "UCI_Variant" ||
+            cmd[2] == "USI_Variant" ||
+            cmd[2] == "UCCI_Variant")
         ) {
           window.alert(
             "Cannot send this command: To change the variant, select the items in the variants dropdown.",
@@ -1611,35 +2156,84 @@
         }
         if (cmd[0] == "usi") {
           window.alert(
-            "Cannot send this command: Fairyground only accepts UCI protocol.",
+            "Cannot send this command: Change engine protocol in engine management UI. In browser Fairy-Stockfish only accepts UCI protocol.",
           );
           return;
         }
         if (cmd[0] == "ucci") {
           window.alert(
-            "Cannot send this command: Fairyground only accepts UCI protocol.",
+            "Cannot send this command: Change engine protocol in engine management UI. In browser Fairy-Stockfish only accepts UCI protocol.",
           );
           return;
         }
         if (cmd[0] == "xboard") {
           window.alert(
-            "Cannot send this command: Fairyground only accepts UCI protocol.",
+            "Cannot send this command: Change engine protocol in engine management UI. In browser Fairy-Stockfish only accepts UCI protocol.",
           );
           return;
         }
         if (cmd[0] == "ucicyclone") {
           window.alert(
-            "Cannot send this command: Fairyground only accepts UCI protocol.",
+            "Cannot send this command: Change engine protocol in engine management UI. In browser Fairy-Stockfish only accepts UCI protocol.",
           );
           return;
         }
         if (cmd[0] == "uci") {
           window.alert(
-            "Cannot send this command: This will reset engine status leaving UI status unchanged.",
+            "Cannot send this command: Change engine protocol in engine management UI. In browser Fairy-Stockfish only accepts UCI protocol.",
           );
           return;
         }
-        stockfish.postMessage($("#enginecmd").value);
+        const targetengine = document.getElementById("targetengine");
+        if (targetengine[targetengine.selectedIndex].value == "WHITE") {
+          if (fge.WebSocketStatus == "CONNECTED") {
+            if (fge.first_engine) {
+              fge.first_engine.PostMessage($("#enginecmd").value.trim());
+            } else {
+              window.alert("1st engine is not loaded.");
+            }
+          } else if (window.location.hostname != "localhost") {
+            window.alert("This feature is only available in offline versions.");
+          } else {
+            window.alert(
+              "Connection lost with the server. Try reloading the page.",
+            );
+          }
+        } else if (targetengine[targetengine.selectedIndex].value == "BLACK") {
+          if (fge.WebSocketStatus == "CONNECTED") {
+            if (fge.second_engine) {
+              fge.second_engine.PostMessage($("#enginecmd").value.trim());
+            } else {
+              window.alert("2nd engine is not loaded.");
+            }
+          } else if (window.location.hostname != "localhost") {
+            window.alert("This feature is only available in offline versions.");
+          } else {
+            window.alert(
+              "Connection lost with the server. Try reloading the page.",
+            );
+          }
+        } else if (
+          targetengine[targetengine.selectedIndex].value == "ANALYSIS"
+        ) {
+          if (fge.WebSocketStatus == "CONNECTED") {
+            if (fge.analysis_engine) {
+              fge.analysis_engine.PostMessage($("#enginecmd").value.trim());
+            } else {
+              window.alert("Analysis engine is not loaded.");
+            }
+          } else if (window.location.hostname != "localhost") {
+            window.alert("This feature is only available in offline versions.");
+          } else {
+            window.alert(
+              "Connection lost with the server. Try reloading the page.",
+            );
+          }
+        } else if (
+          targetengine[targetengine.selectedIndex].value == "DEFAULT"
+        ) {
+          stockfish.postMessage($("#enginecmd").value.trim());
+        }
       };
 
       const totalMoveNumber = () => {
@@ -1671,7 +2265,7 @@
           if (is_force_stop) {
             force_stop();
           } else {
-            stop();
+            stop(true);
           }
           $("#displaymoves").value = $("#move").value;
           review_mode = false;
@@ -1683,7 +2277,7 @@
           if (is_force_stop) {
             force_stop();
           } else {
-            stop();
+            stop(true);
           }
           if ($("#showmovediv").checked) {
             $("#showmovediv").click();
@@ -1704,14 +2298,38 @@
             }
           }
         }
-        const fen = $("#fen").value;
-        const display_moves = $("#displaymoves").value;
+        const fen = $("#fen").value.trim();
+        const display_moves = $("#displaymoves").value.trim();
         if (fen.length > 0) {
           stockfish.postMessage(`position fen ${fen} moves ${display_moves}`);
         } else {
           stockfish.postMessage(`position startpos moves ${display_moves}`);
         }
-        console.log(`${display_moves}`);
+        if (fge.first_engine) {
+          fge.first_engine.SetPosition(
+            fen,
+            display_moves,
+            fge.GetBoardWidth(),
+            fge.GetBoardHeight(),
+          );
+        }
+        if (fge.second_engine) {
+          fge.second_engine.SetPosition(
+            fen,
+            display_moves,
+            fge.GetBoardWidth(),
+            fge.GetBoardHeight(),
+          );
+        }
+        if (fge.analysis_engine) {
+          fge.analysis_engine.SetPosition(
+            fen,
+            display_moves,
+            fge.GetBoardWidth(),
+            fge.GetBoardHeight(),
+          );
+        }
+        //console.log(`${display_moves}`);
         $("#displayready").value = 1; //1 = updateChessBoardToPosition() working
       };
 
@@ -1786,7 +2404,16 @@
         $("#fen").value = "";
         $("#move").value = "";
         resetTimer();
-        setFen();
+        if (fge.first_engine) {
+          fge.first_engine.NewGame();
+        }
+        if (fge.second_engine) {
+          fge.second_engine.NewGame();
+        }
+        if (fge.analysis_engine) {
+          fge.analysis_engine.NewGame();
+        }
+        setFen(true, false);
         $("#currentposition").click();
       };
 
@@ -1796,8 +2423,17 @@
         }
         const moves = $("#move").value;
         $("#move").value = moves.substring(0, moves.lastIndexOf(" "));
+        if (fge.first_engine) {
+          fge.first_engine.NewGame();
+        }
+        if (fge.second_engine) {
+          fge.second_engine.NewGame();
+        }
+        if (fge.analysis_engine) {
+          fge.analysis_engine.NewGame();
+        }
         resetTimer();
-        setFen();
+        setFen(true, false);
       };
 
       const go = () => {
@@ -1805,16 +2441,23 @@
           return;
         }
         return_early = play_move;
-        stop();
         console.log(`return early: ${return_early}`);
         if (return_early) return; // avoid race condition
         let args = "";
+        let wargs = "";
+        let bargs = "";
         const movetime = $("#movetime").value;
         const depth = $("#depth").value;
         const nodes = $("#nodes").value;
         const threadnum = $("#threads").value;
         const hashsize = $("#hash").value;
         const multipleprincipalvariation = $("#multipv").value;
+        let whitedepthv = parseInt($("#whitedepth").value);
+        let whitemovetimev = parseInt($("#whitemovetime").value);
+        let whitenodesv = parseInt($("#whitenodes").value);
+        let blackdepthv = parseInt($("#blackdepth").value);
+        let blackmovetimev = parseInt($("#blackmovetime").value);
+        let blacknodesv = parseInt($("#blacknodes").value);
         let wtime = 0;
         let btime = 0;
         let winc = 0;
@@ -1827,19 +2470,21 @@
             $("#label-stm").innerHTML == "white"
           ) {
             args += "infinite";
+            wargs += "infinite";
             console.log("wtime infinite");
           } else if (
             black_timer_type == "infinite" &&
             $("#label-stm").innerHTML == "black"
           ) {
             args += "infinite";
+            bargs += "infinite";
             console.log("btime infinite");
           } else {
             if (white_timer_type == "time per move") {
-              wtime += +white_moving_time_list[0];
-              winc += +white_moving_time_list[0];
+              wtime += +white_moving_time_list[0].remaining_time;
+              winc += +white_moving_time_list[0].remaining_time;
             } else if (white_timer_type == "tournament") {
-              wtime += +(+white_remaining_time + +white_time_gain);
+              wtime += +(+white_remaining_time);
               winc += +white_time_gain;
             } else if (white_timer_type == "hourglass") {
               //How to tell that it's hourglass to engine?
@@ -1860,10 +2505,10 @@
               }
             }
             if (black_timer_type == "time per move") {
-              btime += +black_moving_time_list[0];
-              binc += +black_moving_time_list[0];
+              btime += +black_moving_time_list[0].remaining_time;
+              binc += +black_moving_time_list[0].remaining_time;
             } else if (black_timer_type == "tournament") {
-              btime += +(+black_remaining_time + +black_time_gain);
+              btime += +(+black_remaining_time);
               binc = +black_time_gain;
             } else if (black_timer_type == "hourglass") {
               //How to tell that it's hourglass to engine?
@@ -1901,6 +2546,24 @@
           if (!analysis_mode && $("#nodes").validity.valid && nodes > 0) {
             args += ` nodes ${nodes}`;
           }
+          if (!($("#whitedepth").validity.valid && whitedepthv > 0)) {
+            whitedepth = -1;
+          }
+          if (!($("#whitemovetime").validity.valid && whitemovetimev > 0)) {
+            whitemovetime = -1;
+          }
+          if (!($("#whitenodes").validity.valid && whitenodesv > 0)) {
+            whitenodes = -1;
+          }
+          if (!($("#blackdepth").validity.valid && blackdepthv > 0)) {
+            blackdepth = -1;
+          }
+          if (!($("#blackmovetime").validity.valid && blackmovetimev > 0)) {
+            blackmovetime = -1;
+          }
+          if (!($("#blacknodes").validity.valid && blacknodesv > 0)) {
+            blacknodes = -1;
+          }
         }
 
         if (threadnum.length <= 0 || threadnum < 1) {
@@ -1935,8 +2598,206 @@
         const stm = $("#label-stm").innerText;
         play_move =
           (play_white && stm == "white") || (play_black && stm == "black");
-        stockfish.postMessage(`go ${args}`);
-        output2 = "";
+        if (fge.WebSocketStatus == "CONNECTED") {
+          if (analysis_mode) {
+            if (fge.analysis_engine) {
+              if (fge.analysis_engine.IsUsing) {
+                analysis_engine_output = "";
+                fge.analysis_engine.IsAnalysisEngine = true;
+                fge.analysis_engine.StartThinking(
+                  stm,
+                  false,
+                  false,
+                  false,
+                  false,
+                  -1,
+                  -1,
+                  -1,
+                  wtime,
+                  winc,
+                  btime,
+                  binc,
+                  white_byoyomi_time_per_period,
+                );
+              } else {
+                stockfish.postMessage(`go ${args}`);
+              }
+            } else {
+              stockfish.postMessage(`go ${args}`);
+            }
+          } else if (stm == "white") {
+            if (fge.first_engine) {
+              if (fge.first_engine.IsUsing) {
+                if (
+                  advanced_time_control &&
+                  fge.first_engine.Ponder &&
+                  fge.first_engine.PonderMove ==
+                    $("#move").value.trim().split(" ").at(-1)
+                ) {
+                  fge.first_engine.StartThinking(
+                    stm,
+                    true,
+                    false,
+                    true,
+                    white_timer_type == "byoyomi",
+                    whitedepthv,
+                    whitemovetimev,
+                    whitenodesv,
+                    wtime,
+                    winc,
+                    btime,
+                    binc,
+                    white_byoyomi_time_per_period,
+                  );
+                  console.log(
+                    `%c Ponder %c HIT %c WHITE Ponder Hits`,
+                    "color: #fff; background: #5f5f5f",
+                    "color: #fff; background: #4bc729",
+                    "",
+                  );
+                } else {
+                  first_engine_output = "";
+                  fge.first_engine.StartThinking(
+                    stm,
+                    advanced_time_control,
+                    false,
+                    false,
+                    white_timer_type == "byoyomi",
+                    whitedepthv,
+                    whitemovetimev,
+                    whitenodesv,
+                    wtime,
+                    winc,
+                    btime,
+                    binc,
+                    white_byoyomi_time_per_period,
+                  );
+                  //console.log("WHITE: go " + wargs);
+                }
+              } else {
+                output2 = "";
+                stockfish.postMessage(`go ${args}`);
+              }
+            } else {
+              output2 = "";
+              stockfish.postMessage(`go ${args}`);
+            }
+            if (fge.second_engine) {
+              if (fge.second_engine.IsUsing) {
+                if (
+                  advanced_time_control &&
+                  white_timer_type != "infinite" &&
+                  fge.second_engine.Ponder &&
+                  fge.second_engine.PonderMove != "0000"
+                ) {
+                  second_engine_output = "";
+                  fge.second_engine.StartThinking(
+                    stm,
+                    true,
+                    true,
+                    false,
+                    black_timer_type == "byoyomi",
+                    blackdepthv,
+                    blackmovetimev,
+                    blacknodesv,
+                    wtime,
+                    winc,
+                    btime,
+                    binc,
+                    black_byoyomi_time_per_period,
+                  );
+                }
+              }
+            }
+          } else if (stm == "black") {
+            if (fge.second_engine) {
+              if (fge.second_engine.IsUsing) {
+                if (
+                  advanced_time_control &&
+                  fge.second_engine.Ponder &&
+                  fge.second_engine.PonderMove ==
+                    $("#move").value.trim().split(" ").at(-1)
+                ) {
+                  fge.second_engine.StartThinking(
+                    stm,
+                    true,
+                    false,
+                    true,
+                    black_timer_type == "byoyomi",
+                    blackdepthv,
+                    blackmovetimev,
+                    blacknodesv,
+                    wtime,
+                    winc,
+                    btime,
+                    binc,
+                    black_byoyomi_time_per_period,
+                  );
+                  console.log(
+                    `%c Ponder %c HIT %c BLACK Ponder Hits`,
+                    "color: #fff; background: #5f5f5f",
+                    "color: #fff; background: #4bc729",
+                    "",
+                  );
+                } else {
+                  second_engine_output = "";
+                  fge.second_engine.StartThinking(
+                    stm,
+                    advanced_time_control,
+                    false,
+                    false,
+                    black_timer_type == "byoyomi",
+                    blackdepthv,
+                    blackmovetimev,
+                    blacknodesv,
+                    wtime,
+                    winc,
+                    btime,
+                    binc,
+                    white_byoyomi_time_per_period,
+                  );
+                  //console.log("BLACK: go " + bargs);
+                }
+              } else {
+                output2 = "";
+                stockfish.postMessage(`go ${args}`);
+              }
+            } else {
+              output2 = "";
+              stockfish.postMessage(`go ${args}`);
+            }
+            if (fge.first_engine) {
+              if (fge.first_engine.IsUsing) {
+                if (
+                  advanced_time_control &&
+                  black_timer_type != "infinite" &&
+                  fge.first_engine.Ponder &&
+                  fge.first_engine.PonderMove != "0000"
+                ) {
+                  first_engine_output = "";
+                  fge.first_engine.StartThinking(
+                    stm,
+                    true,
+                    true,
+                    false,
+                    white_timer_type == "byoyomi",
+                    whitedepthv,
+                    whitemovetimev,
+                    whitenodesv,
+                    wtime,
+                    winc,
+                    btime,
+                    binc,
+                    white_byoyomi_time_per_period,
+                  );
+                }
+              }
+            }
+          }
+        } else {
+          output2 = "";
+          stockfish.postMessage(`go ${args}`);
+        }
       };
 
       const setupTimer = () => {
@@ -2031,8 +2892,15 @@
         }
         white_moving_time_list = [];
         black_moving_time_list = [];
-        white_moving_time_list.push(white_remaining_time); //Start time white
-        black_moving_time_list.push(black_remaining_time); //Start time black
+        const now = Date.now();
+        white_moving_time_list.push({
+          remaining_time: white_remaining_time,
+          time_stamp: now,
+        }); //Start time white
+        black_moving_time_list.push({
+          remaining_time: black_remaining_time,
+          time_stamp: now,
+        }); //Start time black
         $("#whitetime").innerHTML = `${parseInt(white_remaining_time / 1000)}`;
         $("#blacktime").innerHTML = `${parseInt(black_remaining_time / 1000)}`;
         if (white_timer_type == "infinite") {
@@ -2051,32 +2919,41 @@
         $("#timeoutside").value = 0;
       };
 
-      function updateTimer() {
-        if ($("#gamestatus").innerHTML == "END") {
-          deleteTimer();
-          gameEnd();
+      function updateTimerOnMove() {
+        if (!during_play) {
           return;
         }
-        $("#gamestatus").click();
+        move_finish_timer_updating = true;
+        const stm = document.getElementById("label-stm").innerText;
         console.log(`${$("#gamestatus").innerHTML}`);
-        if ($("#gamestatus").innerHTML == "PLAYING_WHITE") {
+        //console.log(white_moving_time_list);
+        //console.log(white_moving_time_list);
+        const now = Date.now();
+        if (stm == "white") {
           if (previous_mover == "") {
             if (white_timer_type == "tournament") {
               white_remaining_time =
                 +white_remaining_time + +white_time_gain + +timer_interval;
             }
-            white_moving_time_list.push(white_remaining_time); //Time stamp for white's turn begin
-          } else if (previous_mover == "BLACK") {
-            black_moving_time_list.push(black_remaining_time); //Time stamp for black's turn end
+            white_moving_time_list.push({
+              remaining_time: white_remaining_time,
+              time_stamp: now,
+            }); //Time stamp for white's turn begin
+          } else {
+            black_moving_time_list.push({
+              remaining_time: black_remaining_time,
+              time_stamp: now,
+            }); //Time stamp for black's turn end
             if (black_remaining_time < 0) {
               black_remaining_time = 0;
             }
+            //white_remaining_time = (+white_moving_time_list.at(-1).remaining_time) + ((+white_moving_time_list.at(-1).time_stamp) - (+now));
             if (white_timer_type == "tournament") {
               white_remaining_time =
                 +white_remaining_time + +white_time_gain + +timer_interval;
             } else if (white_timer_type == "time per move") {
               white_remaining_time =
-                +white_moving_time_list[0] + +timer_interval;
+                +white_moving_time_list[0].remaining_time + +timer_interval;
             } else if (white_timer_type == "byoyomi") {
               if (
                 white_remaining_byoyomi_periods < white_byoyomi_period_count
@@ -2090,12 +2967,79 @@
             if (black_timer_type == "hourglass") {
               white_remaining_time =
                 +white_remaining_time +
-                +black_moving_time_list.at(-2) -
-                +black_moving_time_list.at(-1) +
-                +timer_interval;
+                +black_moving_time_list.at(-2).remaining_time -
+                +black_moving_time_list.at(-1).remaining_time;
             }
-            white_moving_time_list.push(white_remaining_time); //Time stamp for white's turn begin
+            white_moving_time_list.push({
+              remaining_time: white_remaining_time,
+              time_stamp: now,
+            }); //Time stamp for white's turn begin
           }
+          previous_mover = "WHITE";
+        } else if (stm == "black") {
+          if (previous_mover == "") {
+            if (black_timer_type == "tournament") {
+              black_remaining_time =
+                +black_remaining_time + +black_time_gain + +timer_interval;
+            }
+            black_moving_time_list.push({
+              remaining_time: black_remaining_time,
+              time_stamp: now,
+            }); //Time stamp for black's turn begin
+          } else {
+            white_moving_time_list.push({
+              remaining_time: white_remaining_time,
+              time_stamp: now,
+            }); //Time stamp for white's turn end
+            if (white_remaining_time < 0) {
+              white_remaining_time = 0;
+            }
+            //black_remaining_time = (+black_moving_time_list.at(-1).remaining_time) + ((+black_moving_time_list.at(-1).time_stamp) - (+now));
+            if (black_timer_type == "tournament") {
+              black_remaining_time =
+                +black_remaining_time + +black_time_gain + +timer_interval;
+            } else if (black_timer_type == "time per move") {
+              black_remaining_time =
+                +black_moving_time_list[0].remaining_time + +timer_interval;
+            } else if (black_timer_type == "byoyomi") {
+              if (
+                black_remaining_byoyomi_periods < black_byoyomi_period_count
+              ) {
+                black_remaining_time =
+                  +black_byoyomi_time_per_period + +timer_interval;
+              } else {
+                black_remaining_time = +black_remaining_time + +timer_interval;
+              }
+            }
+            if (white_timer_type == "hourglass") {
+              black_remaining_time =
+                +black_remaining_time +
+                +white_moving_time_list.at(-2).remaining_time -
+                +white_moving_time_list.at(-1).remaining_time;
+            }
+            black_moving_time_list.push({
+              remaining_time: black_remaining_time,
+              time_stamp: now,
+            }); //Time stamp for black's turn begin
+          }
+          previous_mover = "BLACK";
+        }
+        move_finish_timer_updating = false;
+      }
+
+      function updateTimer() {
+        if ($("#gamestatus").innerHTML == "END") {
+          deleteTimer();
+          gameEnd();
+          return;
+        }
+        if (move_finish_timer_updating) {
+          //avoid race condition
+          return;
+        }
+        $("#gamestatus").click();
+        console.log(`${$("#gamestatus").innerHTML}`);
+        if ($("#gamestatus").innerHTML == "PLAYING_WHITE") {
           if (white_timer_type == "infinite") {
             previous_mover = "WHITE";
             return;
@@ -2150,42 +3094,6 @@
           }
           previous_mover = "WHITE";
         } else if ($("#gamestatus").innerHTML == "PLAYING_BLACK") {
-          if (previous_mover == "") {
-            if (black_timer_type == "tournament") {
-              black_remaining_time =
-                +black_remaining_time + +black_time_gain + +timer_interval;
-            }
-            black_moving_time_list.push(black_remaining_time); //Time stamp for black's turn begin
-          } else if (previous_mover == "WHITE") {
-            white_moving_time_list.push(white_remaining_time); //Time stamp for white's turn end
-            if (white_remaining_time < 0) {
-              white_remaining_time = 0;
-            }
-            if (black_timer_type == "tournament") {
-              black_remaining_time =
-                +black_remaining_time + +black_time_gain + +timer_interval;
-            } else if (black_timer_type == "time per move") {
-              black_remaining_time =
-                +black_moving_time_list[0] + +timer_interval;
-            } else if (black_timer_type == "byoyomi") {
-              if (
-                black_remaining_byoyomi_periods < black_byoyomi_period_count
-              ) {
-                black_remaining_time =
-                  +black_byoyomi_time_per_period + +timer_interval;
-              } else {
-                black_remaining_time = +black_remaining_time + +timer_interval;
-              }
-            }
-            if (white_timer_type == "hourglass") {
-              black_remaining_time =
-                +black_remaining_time +
-                +white_moving_time_list.at(-2) -
-                +white_moving_time_list.at(-1) +
-                +timer_interval;
-            }
-            black_moving_time_list.push(black_remaining_time); //Time stamp for black's turn begin
-          }
           if (black_timer_type == "infinite") {
             previous_mover = "BLACK";
             return;
@@ -2299,6 +3207,15 @@
         $("#gamestatus").click();
         during_play = true;
         $("#currentposition").click();
+        if (fge.first_engine) {
+          fge.first_engine.PonderMove = "0000";
+          fge.first_engine.PonderMiss = false;
+        }
+        if (fge.second_engine) {
+          fge.second_engine.PonderMove = "0000";
+          fge.second_engine.PonderMiss = false;
+        }
+        updateTimerOnMove();
         createTimer();
         const stm = $("#label-stm").innerText;
         console.log(
@@ -2312,13 +3229,29 @@
         }
       };
 
-      const stop = () => {
+      const stop = (interrupt_pondering) => {
         stockfish.postMessage(`stop`);
+        if (fge.first_engine) {
+          fge.first_engine.StopThinking(
+            interrupt_pondering,
+            advanced_time_control,
+          );
+        }
+        if (fge.second_engine) {
+          fge.second_engine.StopThinking(
+            interrupt_pondering,
+            advanced_time_control,
+          );
+        }
+        if (fge.analysis_engine) {
+          fge.analysis_engine.StopThinking(true, false);
+        }
       };
 
       const force_stop = () => {
         play_white = play_black = false;
-        stop();
+        play_move = false;
+        stop(true);
       };
 
       const changePieces = (onlyChangeWhenInvalid) => {
@@ -2443,7 +3376,7 @@
             newOption.text = getThemeName(val);
             newOption.value = val;
             piecethemedropdown.add(newOption);
-            console.log(val);
+            //console.log(val);
           });
         } else {
           let newOption = document.createElement("option");
@@ -2461,7 +3394,7 @@
             newOption.text = getThemeName(val);
             newOption.value = val;
             boardthemedropdown.add(newOption);
-            console.log(val);
+            //console.log(val);
           });
         } else {
           let newOption = document.createElement("option");
@@ -2555,7 +3488,6 @@
         });
         variantdropdown.selectedIndex = 0;
         //updateVariantDropdownTitles();
-        variantdropdown.dispatchEvent(new Event("change"));
       };
 
       const updateVariantTypeDropdown = () => {
@@ -2598,7 +3530,8 @@
           varianttypedropdown.appendChild(option);
         });
         varianttypedropdown.selectedIndex = 0;
-        updateVariantDropdown();
+        changing_variant_type = true;
+        $("#dropdown-variant").dispatchEvent(new Event("change"));
       };
 
       const scrollOutput = () => {
@@ -2670,8 +3603,15 @@
                   $("#set").click();
                 }
                 output2 += line + "\n";
-                $("#engineoutputline").value = line;
-                $("#engineoutputline").click();
+                if (fge.analysis_engine) {
+                  if (!fge.analysis_engine.IsUsing) {
+                    $("#engineoutputline").value = line;
+                    $("#engineoutputline").click();
+                  }
+                } else {
+                  $("#engineoutputline").value = line;
+                  $("#engineoutputline").click();
+                }
               }
               m.redraw();
             });
@@ -2952,7 +3892,8 @@
               {
                 disabled: !is_ready || review_mode || board_setup_mode,
                 onchange: (e) => {
-                  updateVariantDropdown();
+                  changing_variant_type = true;
+                  $("#dropdown-variant").dispatchEvent(new Event("change"));
                 },
               },
               [
@@ -2966,6 +3907,10 @@
               {
                 disabled: !is_ready || review_mode || board_setup_mode,
                 onchange: (e) => {
+                  if (changing_variant_type) {
+                    updateVariantDropdown();
+                    changing_variant_type = false;
+                  }
                   window.setTimeout(setVariant, 10);
                 },
               },
@@ -3035,7 +3980,7 @@
                   e.redraw = false;
                   return;
                 }
-                setFen();
+                setFen(true, false);
               },
             }),
             m("input#move", {
@@ -3046,7 +3991,7 @@
                   e.redraw = false;
                   return;
                 }
-                setFen();
+                setFen(true, false);
               },
             }),
             m(
@@ -3058,7 +4003,18 @@
                     return;
                   }
                   resetTimer();
-                  window.setTimeout(setFen, 10);
+                  if (fge.first_engine) {
+                    fge.first_engine.NewGame();
+                  }
+                  if (fge.second_engine) {
+                    fge.second_engine.NewGame();
+                  }
+                  if (fge.analysis_engine) {
+                    fge.analysis_engine.NewGame();
+                  }
+                  window.setTimeout(() => {
+                    setFen(true, false);
+                  }, 10);
                   $("#currentposition").click();
                 },
               },
@@ -3078,6 +4034,88 @@
               },
               "◀️Undo",
             ),
+          ]),
+          m("div#binengineinput", { hidden: during_play }, [
+            m(
+              "button",
+              {
+                onclick: () => {
+                  fge.ShowEngineManagementUI(engine_list, fge.ws);
+                },
+              },
+              "Engine Management",
+            ),
+            m("div#whiteenginesettings", [
+              m("p", "1st binary engine settings:"),
+              m("input[type=number]#whitedepth", {
+                placeholder: "Depth",
+                disabled:
+                  !is_ready ||
+                  fge.WebSocketStatus != "CONNECTED" ||
+                  analysis_mode,
+                min: 1,
+              }),
+              m("input[type=number]#whitemovetime", {
+                placeholder: "Movetime",
+                disabled:
+                  !is_ready ||
+                  fge.WebSocketStatus != "CONNECTED" ||
+                  analysis_mode,
+                min: 0,
+              }),
+              m("input[type=number]#whitenodes", {
+                placeholder: "Nodes",
+                disabled:
+                  !is_ready ||
+                  fge.WebSocketStatus != "CONNECTED" ||
+                  analysis_mode,
+                min: 1,
+              }),
+              m(
+                "p#whiteunsupportedvariant",
+                { hidden: true },
+                "1st engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+              ),
+            ]),
+            m("div#blackenginesettings", [
+              m("p", "2nd binary engine settings:"),
+              m("input[type=number]#blackdepth", {
+                placeholder: "Depth",
+                disabled:
+                  !is_ready ||
+                  fge.WebSocketStatus != "CONNECTED" ||
+                  analysis_mode,
+                min: 1,
+              }),
+              m("input[type=number]#blackmovetime", {
+                placeholder: "Movetime",
+                disabled:
+                  !is_ready ||
+                  fge.WebSocketStatus != "CONNECTED" ||
+                  analysis_mode,
+                min: 0,
+              }),
+              m("input[type=number]#blacknodes", {
+                placeholder: "Nodes",
+                disabled:
+                  !is_ready ||
+                  fge.WebSocketStatus != "CONNECTED" ||
+                  analysis_mode,
+                min: 1,
+              }),
+              m(
+                "p#blackunsupportedvariant",
+                { hidden: true },
+                "2nd engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+              ),
+            ]),
+            m("div#analysisenginesettings", [
+              m(
+                "p#analysisunsupportedvariant",
+                { hidden: true },
+                "Analysis engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+              ),
+            ]),
           ]),
           m("div#input2", { hidden: during_play }, [
             m("p", "Settings:"),
@@ -3123,7 +4161,12 @@
                   if ($("#advtimectrl").checked == true) {
                     $("#advtimectrl").click();
                   }
-                  go();
+                  setTimeout(() => {
+                    if (!review_mode) {
+                      setFen(true, false);
+                    }
+                    go();
+                  }, 10);
                 },
               },
               "▶️Go",
@@ -3235,7 +4278,10 @@
                   if (review_mode) {
                     return;
                   }
-                  window.setTimeout(setFen, 10);
+                  play_move = false;
+                  window.setTimeout(() => {
+                    setFen(false, true);
+                  }, 10);
                 },
                 hidden: true,
               },
@@ -3273,6 +4319,45 @@
                 },
               },
               "Copy Set FEN (internal)",
+            ),
+            m(
+              "p#binengineoutputinit",
+              {
+                hidden: true,
+                onclick: () => {
+                  if (fge.first_engine) {
+                    fge.first_engine.OutputUpdateCallBack = (color, msg) => {
+                      first_engine_output += msg + "\n";
+                      document.getElementById("whiteengineoutput").innerText =
+                        first_engine_output;
+                      scrollOutput();
+                    };
+                  }
+                  if (fge.second_engine) {
+                    fge.second_engine.OutputUpdateCallBack = (color, msg) => {
+                      second_engine_output += msg + "\n";
+                      document.getElementById("blackengineoutput").innerText =
+                        second_engine_output;
+                      scrollOutput();
+                    };
+                  }
+                  if (fge.analysis_engine) {
+                    fge.analysis_engine.OutputUpdateCallBack = (color, msg) => {
+                      analysis_engine_output += msg + "\n";
+                      document.getElementById(
+                        "analysisengineoutput",
+                      ).innerText = analysis_engine_output;
+                      scrollOutput();
+                    };
+                    fge.analysis_engine.EvaluationUpdateCallBack = (msg) => {
+                      document.getElementById("engineoutputline").value = msg;
+                      document.getElementById("engineoutputline").click();
+                    };
+                  }
+                  scrollOutput();
+                },
+              },
+              "Binary Engine Output Event Handler Initialization (internal)",
             ),
           ]),
           m(
@@ -3801,7 +4886,12 @@
               ]),
               m("p#currentboardfen"),
               m("p#label-pgn"),
-              m("div#output2", { onupdate: scrollOutput }, m("pre", output2)),
+              m("div#output2", { onupdate: scrollOutput }, [
+                m("pre#fsfoutput", output2),
+                m("pre#whiteengineoutput", { hidden: true }, ""),
+                m("pre#blackengineoutput", { hidden: true }, ""),
+                m("pre#analysisengineoutput", { hidden: true }, ""),
+              ]),
               m("div#enginecmddiv", [
                 m("input#enginecmd", {
                   placeholder: "Send command to engine...",
@@ -3817,6 +4907,61 @@
                     sendCommandToEngine();
                   },
                 }),
+                m(
+                  "select#targetengine",
+                  {
+                    onchange: () => {
+                      let index = $("#targetengine").selectedIndex;
+                      if (index == 0) {
+                        document.getElementById("fsfoutput").hidden = false;
+                        document.getElementById("whiteengineoutput").hidden =
+                          true;
+                        document.getElementById("blackengineoutput").hidden =
+                          true;
+                        document.getElementById("analysisengineoutput").hidden =
+                          true;
+                      } else if (index == 1) {
+                        document.getElementById("fsfoutput").hidden = true;
+                        document.getElementById("whiteengineoutput").hidden =
+                          false;
+                        document.getElementById("blackengineoutput").hidden =
+                          true;
+                        document.getElementById("analysisengineoutput").hidden =
+                          true;
+                      } else if (index == 2) {
+                        document.getElementById("fsfoutput").hidden = true;
+                        document.getElementById("whiteengineoutput").hidden =
+                          true;
+                        document.getElementById("blackengineoutput").hidden =
+                          false;
+                        document.getElementById("analysisengineoutput").hidden =
+                          true;
+                      } else if (index == 3) {
+                        document.getElementById("fsfoutput").hidden = true;
+                        document.getElementById("whiteengineoutput").hidden =
+                          true;
+                        document.getElementById("blackengineoutput").hidden =
+                          true;
+                        document.getElementById("analysisengineoutput").hidden =
+                          false;
+                      }
+                    },
+                  },
+                  [
+                    m(
+                      "option",
+                      { value: "DEFAULT" },
+                      "In browser Fairy-Stockfish",
+                    ),
+                    m("option", { value: "WHITE" }, "1st binary engine"),
+                    m("option", { value: "BLACK" }, "2nd binary engine"),
+                    m(
+                      "option",
+                      { value: "ANALYSIS" },
+                      "Analysis binary engine",
+                    ),
+                  ],
+                ),
                 m(
                   "button#sendenginecmd",
                   {

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -435,6 +435,10 @@
     height: 600px;
   }
 
+  #info #sannotation {
+    background: #eee;
+  }
+
   #info #timecontrolduringplay {
     padding: 10px;
     margin-left: 20px;
@@ -2636,7 +2640,9 @@
 
         const stm = $("#label-stm").innerText;
         play_move =
-          (play_white && stm == "white") || (play_black && stm == "black");
+          (play_white && stm == "white") ||
+          (play_black && stm == "black") ||
+          analysis_mode;
         if (fge.WebSocketStatus == "CONNECTED") {
           if (analysis_mode) {
             if (fge.analysis_engine) {
@@ -4216,7 +4222,21 @@
             ),
             m(
               "button#stop",
-              { disabled: !is_ready, onclick: force_stop },
+              {
+                disabled: !is_ready,
+                onclick: () => {
+                  force_stop();
+                  if (fge.first_engine) {
+                    fge.first_engine.ForceStop();
+                  }
+                  if (fge.second_engine) {
+                    fge.second_engine.ForceStop();
+                  }
+                  if (fge.analysis_engine) {
+                    fge.analysis_engine.ForceStop();
+                  }
+                },
+              },
               "⏹Stop",
             ),
             m(
@@ -4875,6 +4895,82 @@
               ]),
             ]),
             m("div#info", [
+              m("select#sannotation", [
+                m("option", { value: "" }, "--Select Notation System--"),
+                m(
+                  "option",
+                  { value: "DEFAULT" },
+                  "Standard/Short Algebraic Notation Without Piece Type Omission (DEFAULT)",
+                ),
+                m(
+                  "option",
+                  { value: "SAN" },
+                  "Standard/Short Algebraic Notation (SAN)",
+                ),
+                m("option", { value: "LAN" }, "Long Algebraic Notation (LAN)"),
+                m(
+                  "option",
+                  { value: "SHOGI_HOSKING" },
+                  "Shogi Hosking Notation (SHOGI_HOSKING)",
+                ),
+                m(
+                  "option",
+                  { value: "SHOGI_HODGES" },
+                  "Shogi George Hodges Notation (SHOGI_HODGES)",
+                ),
+                m(
+                  "option",
+                  { value: "SHOGI_HODGES_NUMBER" },
+                  "Shogi George Hodges Number-only Notation (SHOGI_HODGES_NUMBER)",
+                ),
+                m("option", { value: "JANGGI" }, "Janggi Notation (JANGGI)"),
+                m(
+                  "option",
+                  { value: "XIANGQI_WXF" },
+                  "World Xiangqi Federation Notation (XIANGQI_WXF)",
+                ),
+                m(
+                  "option",
+                  { value: "THAI_SAN" },
+                  "Thai Standard/Short Algebraic Notation (THAI_SAN)",
+                ),
+                m(
+                  "option",
+                  { value: "THAI_LAN" },
+                  "Thai Long Algebraic Notation (THAI_LAN)",
+                ),
+                m(
+                  "option",
+                  { value: "FEN" },
+                  "Forsyth–Edwards Notation (Fairy-Stockfish) (FEN)",
+                ),
+                m("option", { value: "PGN" }, "Portable Game Notation (PGN)"),
+                m(
+                  "option",
+                  { value: "EPD" },
+                  "Extended Position Description (EPD)",
+                ),
+                m(
+                  "option",
+                  { value: "FEN+UCIMOVE" },
+                  "Forsyth–Edwards Notation (Fairy-Stockfish) and UCI Moves (FEN+UCIMOVE)",
+                ),
+                m(
+                  "option",
+                  { value: "FEN+USIMOVE" },
+                  "Forsyth–Edwards Notation (Fairy-Stockfish) and USI Moves (FEN+USIMOVE)",
+                ),
+                m(
+                  "option",
+                  { value: "FEN+UCCIMOVE" },
+                  "Forsyth–Edwards Notation (Fairy-Stockfish) and UCCI (CECP) Moves (FEN+UCCIMOVE)",
+                ),
+                m(
+                  "option",
+                  { value: "SFEN+USIMOVE" },
+                  "Shogi Forsyth–Edwards Notation and USI Moves (SFEN+USIMOVE)",
+                ),
+              ]),
               m("p#positioninfo", ""),
               m("div#timers", { hidden: !advanced_time_control }, [
                 m("div#whitetimer", [

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1743,7 +1743,10 @@
                 );
                 fge.ws.close();
                 fge.WebSocketStatus = "ERROR";
-                document.getElementById("binengineinput").hidden = true;
+                const binenginediv = document.getElementById("binengineinput");
+                if (binenginediv) {
+                  binenginediv.hidden = true;
+                }
                 fge.first_engine = null;
                 fge.second_engine = null;
                 fge.analysis_engine = null;
@@ -1760,7 +1763,11 @@
                   );
                   fge.WebSocketStatus = "CONNECTED";
                   fge.ws.send("READYOK");
-                  document.getElementById("binengineinput").hidden = false;
+                  const binenginediv =
+                    document.getElementById("binengineinput");
+                  if (binenginediv) {
+                    binenginediv.hidden = false;
+                  }
                 } else {
                   console.error(
                     `%c WebSocket %c ERROR %c WebSocket Server conncetion failed: Server returns bad verification code.`,
@@ -1770,7 +1777,11 @@
                   );
                   fge.ws.close();
                   fge.WebSocketStatus = "ERROR";
-                  document.getElementById("binengineinput").hidden = true;
+                  const binenginediv =
+                    document.getElementById("binengineinput");
+                  if (binenginediv) {
+                    binenginediv.hidden = true;
+                  }
                   fge.first_engine = null;
                   fge.second_engine = null;
                   fge.analysis_engine = null;
@@ -1798,7 +1809,10 @@
               );
               console.error(event);
               fge.WebSocketStatus = "CLOSED";
-              document.getElementById("binengineinput").hidden = true;
+              const binenginediv = document.getElementById("binengineinput");
+              if (binenginediv) {
+                binenginediv.hidden = true;
+              }
               fge.first_engine = null;
               fge.second_engine = null;
               fge.analysis_engine = null;
@@ -1816,7 +1830,10 @@
                 "",
               );
               console.error(event);
-              document.getElementById("binengineinput").hidden = true;
+              const binenginediv = document.getElementById("binengineinput");
+              if (binenginediv) {
+                binenginediv.hidden = true;
+              }
               fge.first_engine = null;
               fge.second_engine = null;
               fge.analysis_engine = null;
@@ -1845,7 +1862,10 @@
           window.alert(
             "Cannot initiate WebSocket connection. Binary engine loading feature will be disabled.",
           );
-          document.getElementById("binengineinput").hidden = true;
+          const binenginediv = document.getElementById("binengineinput");
+          if (binenginediv) {
+            binenginediv.hidden = true;
+          }
           fge.first_engine = null;
           fge.second_engine = null;
           fge.analysis_engine = null;
@@ -1859,7 +1879,10 @@
         );
         fge.ws = null;
         fge.WebSocketStatus = "ERROR";
-        document.getElementById("binengineinput").hidden = true;
+        const binenginediv = document.getElementById("binengineinput");
+        if (binenginediv) {
+          binenginediv.hidden = true;
+        }
         fge.first_engine = null;
         fge.second_engine = null;
         fge.analysis_engine = null;

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -3643,13 +3643,11 @@
                 }
               } else if (line.startsWith(" ")) {
               } else {
-                if (
-                  !review_mode &&
-                  line.startsWith("bestmove") &&
-                  ((play_white && stm == "white") ||
-                    (play_black && stm == "black"))
-                ) {
+                if (!review_mode && line.startsWith("bestmove") && play_move) {
                   play_move = false;
+                  if (analysis_mode) {
+                    return;
+                  }
                   $("#move").value += " " + line.split(" ")[1];
                   $("#set").click();
                 }

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -437,6 +437,7 @@
 
   #info #sannotation {
     background: #eee;
+    margin-bottom: 10px;
   }
 
   #info #timecontrolduringplay {
@@ -3642,7 +3643,12 @@
                 }
               } else if (line.startsWith(" ")) {
               } else {
-                if (!review_mode && line.startsWith("bestmove") && play_move) {
+                if (
+                  !review_mode &&
+                  line.startsWith("bestmove") &&
+                  ((play_white && stm == "white") ||
+                    (play_black && stm == "black"))
+                ) {
                   play_move = false;
                   $("#move").value += " " + line.split(" ")[1];
                   $("#set").click();

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1999,7 +1999,7 @@
           } else {
             if (stm == "white") {
               if (fge.first_engine) {
-                if (fge.first_engine.Ponder) {
+                if (fge.first_engine.Ponder && advanced_time_control) {
                   if (
                     fge.first_engine.PonderMove != "0000" &&
                     fge.first_engine.PonderMove !=
@@ -2036,7 +2036,11 @@
                 }
               }
               if (fge.second_engine) {
-                if (fge.second_engine.Ponder) {
+                if (
+                  fge.second_engine.Ponder &&
+                  fge.second_engine.PonderMove != "0000" &&
+                  advanced_time_control
+                ) {
                   fge.second_engine.SetPosition(
                     fen,
                     moves + ` ${fge.second_engine.PonderMove}`,
@@ -2044,6 +2048,14 @@
                     fge.GetBoardHeight(),
                   );
                 } else {
+                  if (fge.second_engine.Ponder && fge.second_engine.IsUsing) {
+                    console.log(
+                      `%c Ponder %c WARNING %c BLACK makes no ponder move but Ponder=true`,
+                      "color: #fff; background: #5f5f5f",
+                      "color: #fff; background: #ffc83d",
+                      "",
+                    );
+                  }
                   fge.second_engine.SetPosition(
                     fen,
                     moves,
@@ -2054,7 +2066,7 @@
               }
             } else if (stm == "black") {
               if (fge.second_engine) {
-                if (fge.second_engine.Ponder) {
+                if (fge.second_engine.Ponder && advanced_time_control) {
                   if (
                     fge.second_engine.PonderMove != "0000" &&
                     fge.second_engine.PonderMove !=
@@ -2091,7 +2103,11 @@
                 }
               }
               if (fge.first_engine) {
-                if (fge.first_engine.Ponder) {
+                if (
+                  fge.first_engine.Ponder &&
+                  fge.first_engine.PonderMove != "0000" &&
+                  advanced_time_control
+                ) {
                   fge.first_engine.SetPosition(
                     fen,
                     moves + ` ${fge.first_engine.PonderMove}`,
@@ -2099,6 +2115,14 @@
                     fge.GetBoardHeight(),
                   );
                 } else {
+                  if (fge.first_engine.Ponder && fge.first_engine.IsUsing) {
+                    console.log(
+                      `%c Ponder %c WARNING %c WHITE makes no ponder move but Ponder=true`,
+                      "color: #fff; background: #5f5f5f",
+                      "color: #fff; background: #ffc83d",
+                      "",
+                    );
+                  }
                   fge.first_engine.SetPosition(
                     fen,
                     moves,
@@ -2119,7 +2143,28 @@
             (play_black && stm == "black") ||
             analysis_mode)
         ) {
-          setTimeout(go(), 10);
+          setTimeout(go(false, false), 10);
+        } else if (automatically_start_engine_thinking) {
+          if (fge.first_engine) {
+            if (
+              fge.first_engine.IsUsing &&
+              fge.first_engine.Ponder &&
+              stm != "undefined" &&
+              play_white
+            ) {
+              setTimeout(go(true, false), 10);
+            }
+          }
+          if (fge.second_engine) {
+            if (
+              fge.second_engine.IsUsing &&
+              fge.second_engine.Ponder &&
+              stm != "undefined" &&
+              play_black
+            ) {
+              setTimeout(go(false, true), 10);
+            }
+          }
         }
       };
 
@@ -2294,7 +2339,7 @@
         return listlength;
       };
 
-      const displayMove = (movenum, is_force_stop) => {
+      const displayMove = (movenum, is_force_stop, interrupt_pondering) => {
         if (
           $("#displayready").value.length > 0 &&
           $("#displayready").value > 0
@@ -2310,7 +2355,7 @@
           if (is_force_stop) {
             force_stop();
           } else {
-            stop(true);
+            stop(interrupt_pondering);
           }
           $("#displaymoves").value = $("#move").value;
           review_mode = false;
@@ -2322,7 +2367,7 @@
           if (is_force_stop) {
             force_stop();
           } else {
-            stop(true);
+            stop(interrupt_pondering);
           }
           if ($("#showmovediv").checked) {
             $("#showmovediv").click();
@@ -2393,7 +2438,7 @@
         if ($("#advtimectrl").checked == true) {
           $("#advtimectrl").click();
         }
-        displayMove($("#gotomovenum").value, true);
+        displayMove($("#gotomovenum").value, true, true);
       };
 
       const displayPreviousMove = () => {
@@ -2411,7 +2456,7 @@
         if ($("#advtimectrl").checked == true) {
           $("#advtimectrl").click();
         }
-        displayMove($("#gotomovenum").value, true);
+        displayMove($("#gotomovenum").value, true, true);
       };
 
       const displayInitialPosition = () => {
@@ -2419,13 +2464,13 @@
         if ($("#advtimectrl").checked == true) {
           $("#advtimectrl").click();
         }
-        displayMove(0, true);
+        displayMove(0, true, true);
       };
 
       const displayCurrentPosition = () => {
         $("#gotomovenum").value = totalMoveNumber();
         console.log(`Current: ${!during_play}`);
-        displayMove(-1, false);
+        displayMove(-1, false, false);
       };
 
       const displaySpecifiedPosition = () => {
@@ -2440,7 +2485,7 @@
         if ($("#advtimectrl").checked == true) {
           $("#advtimectrl").click();
         }
-        displayMove($("#gotomovenum").value, true);
+        displayMove($("#gotomovenum").value, true, true);
       };
 
       const reset = () => {
@@ -2481,7 +2526,10 @@
         setFen(true, false);
       };
 
-      const go = () => {
+      const go = (
+        white_engine_ponder_and_human_black,
+        black_engine_ponder_and_human_white,
+      ) => {
         if (board_setup_mode) {
           return;
         }
@@ -2503,6 +2551,8 @@
         let blackdepthv = parseInt($("#blackdepth").value);
         let blackmovetimev = parseInt($("#blackmovetime").value);
         let blacknodesv = parseInt($("#blacknodes").value);
+        let winf = false;
+        let binf = false;
         let wtime = 0;
         let btime = 0;
         let winc = 0;
@@ -2516,6 +2566,7 @@
           ) {
             args += "infinite";
             wargs += "infinite";
+            winf = true;
             console.log("wtime infinite");
           } else if (
             black_timer_type == "infinite" &&
@@ -2523,64 +2574,60 @@
           ) {
             args += "infinite";
             bargs += "infinite";
+            binf = true;
             console.log("btime infinite");
-          } else {
-            if (white_timer_type == "time per move") {
-              wtime += +white_moving_time_list[0].remaining_time;
-              winc += +white_moving_time_list[0].remaining_time;
-            } else if (white_timer_type == "tournament") {
-              wtime += +(+white_remaining_time);
-              winc += +white_time_gain;
-            } else if (white_timer_type == "hourglass") {
-              //How to tell that it's hourglass to engine?
-              wtime += +white_remaining_time;
-            } else if (white_timer_type == "byoyomi") {
-              wtime += +white_remaining_time;
-              if (
-                white_remaining_time < white_byoyomi_time_per_period &&
-                white_remaining_byoyomi_periods > 0
-              ) {
-                winc += +white_byoyomi_time_per_period;
-              }
-              if (
-                white_remaining_byoyomi_periods == white_byoyomi_period_count
-              ) {
-                wtime += +white_byoyomi_time_per_period;
-                winc = 0;
-              }
-            }
-            if (black_timer_type == "time per move") {
-              btime += +black_moving_time_list[0].remaining_time;
-              binc += +black_moving_time_list[0].remaining_time;
-            } else if (black_timer_type == "tournament") {
-              btime += +(+black_remaining_time);
-              binc = +black_time_gain;
-            } else if (black_timer_type == "hourglass") {
-              //How to tell that it's hourglass to engine?
-              btime += +black_remaining_time;
-            } else if (black_timer_type == "byoyomi") {
-              btime += +black_remaining_time;
-              if (
-                black_remaining_time < black_byoyomi_time_per_period &&
-                black_remaining_byoyomi_periods > 0
-              ) {
-                binc += +black_byoyomi_time_per_period;
-              }
-              if (
-                black_remaining_byoyomi_periods == black_byoyomi_period_count
-              ) {
-                btime += +black_byoyomi_time_per_period;
-                binc = 0;
-              }
-            }
-            console.log(
-              `wtime ${wtime} winc ${winc} btime ${btime} binc ${binc}`,
-            );
-            args += `wtime ${wtime} winc ${winc} btime ${btime} binc ${binc}`;
-            stockfish.postMessage(
-              `setoption name Move Overhead value ${timer_interval}`,
-            );
           }
+          if (white_timer_type == "time per move") {
+            wtime += +white_moving_time_list[0].remaining_time;
+            winc += +white_moving_time_list[0].remaining_time;
+          } else if (white_timer_type == "tournament") {
+            wtime += +(+white_remaining_time);
+            winc += +white_time_gain;
+          } else if (white_timer_type == "hourglass") {
+            //How to tell that it's hourglass to engine?
+            wtime += +white_remaining_time;
+          } else if (white_timer_type == "byoyomi") {
+            wtime += +white_remaining_time;
+            if (
+              white_remaining_time < white_byoyomi_time_per_period &&
+              white_remaining_byoyomi_periods > 0
+            ) {
+              winc += +white_byoyomi_time_per_period;
+            }
+            if (white_remaining_byoyomi_periods == white_byoyomi_period_count) {
+              wtime += +white_byoyomi_time_per_period;
+              winc = 0;
+            }
+          }
+          if (black_timer_type == "time per move") {
+            btime += +black_moving_time_list[0].remaining_time;
+            binc += +black_moving_time_list[0].remaining_time;
+          } else if (black_timer_type == "tournament") {
+            btime += +(+black_remaining_time);
+            binc = +black_time_gain;
+          } else if (black_timer_type == "hourglass") {
+            //How to tell that it's hourglass to engine?
+            btime += +black_remaining_time;
+          } else if (black_timer_type == "byoyomi") {
+            btime += +black_remaining_time;
+            if (
+              black_remaining_time < black_byoyomi_time_per_period &&
+              black_remaining_byoyomi_periods > 0
+            ) {
+              binc += +black_byoyomi_time_per_period;
+            }
+            if (black_remaining_byoyomi_periods == black_byoyomi_period_count) {
+              btime += +black_byoyomi_time_per_period;
+              binc = 0;
+            }
+          }
+          console.log(
+            `wtime ${wtime} winc ${winc} btime ${btime} binc ${binc}`,
+          );
+          args += `wtime ${wtime} winc ${winc} btime ${btime} binc ${binc}`;
+          stockfish.postMessage(
+            `setoption name Move Overhead value ${timer_interval}`,
+          );
         } else {
           if (!analysis_mode && $("#depth").validity.valid && depth > 0) {
             args += ` depth ${depth}`;
@@ -2658,6 +2705,7 @@
                 fge.analysis_engine.IsAnalysisEngine = true;
                 fge.analysis_engine.StartThinking(
                   stm,
+                  true,
                   false,
                   false,
                   false,
@@ -2688,6 +2736,7 @@
                 ) {
                   fge.first_engine.StartThinking(
                     stm,
+                    false,
                     true,
                     false,
                     true,
@@ -2713,6 +2762,7 @@
                   }
                   fge.first_engine.StartThinking(
                     stm,
+                    winf,
                     advanced_time_control,
                     false,
                     false,
@@ -2728,11 +2778,11 @@
                   );
                   //console.log("WHITE: go " + wargs);
                 }
-              } else {
+              } else if (!black_engine_ponder_and_human_white) {
                 output2 = "";
                 stockfish.postMessage(`go ${args}`);
               }
-            } else {
+            } else if (!black_engine_ponder_and_human_white) {
               output2 = "";
               stockfish.postMessage(`go ${args}`);
             }
@@ -2740,7 +2790,6 @@
               if (fge.second_engine.IsUsing) {
                 if (
                   advanced_time_control &&
-                  white_timer_type != "infinite" &&
                   fge.second_engine.Ponder &&
                   fge.second_engine.PonderMove != "0000"
                 ) {
@@ -2749,6 +2798,7 @@
                   }
                   fge.second_engine.StartThinking(
                     stm,
+                    false,
                     true,
                     true,
                     false,
@@ -2776,6 +2826,7 @@
                 ) {
                   fge.second_engine.StartThinking(
                     stm,
+                    false,
                     true,
                     false,
                     true,
@@ -2801,6 +2852,7 @@
                   }
                   fge.second_engine.StartThinking(
                     stm,
+                    binf,
                     advanced_time_control,
                     false,
                     false,
@@ -2816,11 +2868,11 @@
                   );
                   //console.log("BLACK: go " + bargs);
                 }
-              } else {
+              } else if (!white_engine_ponder_and_human_black) {
                 output2 = "";
                 stockfish.postMessage(`go ${args}`);
               }
-            } else {
+            } else if (!white_engine_ponder_and_human_black) {
               output2 = "";
               stockfish.postMessage(`go ${args}`);
             }
@@ -2828,7 +2880,6 @@
               if (fge.first_engine.IsUsing) {
                 if (
                   advanced_time_control &&
-                  black_timer_type != "infinite" &&
                   fge.first_engine.Ponder &&
                   fge.first_engine.PonderMove != "0000"
                 ) {
@@ -2837,6 +2888,7 @@
                   }
                   fge.first_engine.StartThinking(
                     stm,
+                    false,
                     true,
                     true,
                     false,
@@ -3285,7 +3337,7 @@
         );
         if ((play_white && stm == "white") || (play_black && stm == "black")) {
           console.log("Go!");
-          go();
+          go(false, false);
         }
       };
 
@@ -4232,7 +4284,7 @@
                     if (!review_mode) {
                       setFen(true, false);
                     }
-                    go();
+                    go(false, false);
                   }, 10);
                 },
               },
@@ -4410,29 +4462,39 @@
                   if (fge.first_engine) {
                     fge.first_engine.OutputUpdateCallBack = (color, msg) => {
                       first_engine_output += "◀◀ " + msg + "\n";
-                      document.getElementById("whiteengineoutput").innerText =
+                      document.getElementById("whiteengineoutput").textContent =
                         first_engine_output;
                       scrollOutput();
                     };
                     fge.first_engine.SendMessageCallBack = (msg) => {
                       first_engine_output += "\n▶▶ " + msg + "\n\n";
-                      document.getElementById("whiteengineoutput").innerText =
+                      document.getElementById("whiteengineoutput").textContent =
                         first_engine_output;
                       scrollOutput();
+                    };
+                    fge.first_engine.OnErrorMessageCallBack = (msg) => {
+                      if (during_play) {
+                        window.alert(msg);
+                      }
                     };
                   }
                   if (fge.second_engine) {
                     fge.second_engine.OutputUpdateCallBack = (color, msg) => {
                       second_engine_output += "◀◀ " + msg + "\n";
-                      document.getElementById("blackengineoutput").innerText =
+                      document.getElementById("blackengineoutput").textContent =
                         second_engine_output;
                       scrollOutput();
                     };
                     fge.second_engine.SendMessageCallBack = (msg) => {
                       second_engine_output += "\n▶▶ " + msg + "\n\n";
-                      document.getElementById("blackengineoutput").innerText =
+                      document.getElementById("blackengineoutput").textContent =
                         second_engine_output;
                       scrollOutput();
+                    };
+                    fge.second_engine.OnErrorMessageCallBack = (msg) => {
+                      if (during_play) {
+                        window.alert(msg);
+                      }
                     };
                   }
                   if (fge.analysis_engine) {
@@ -4440,7 +4502,7 @@
                       analysis_engine_output += "◀◀ " + msg + "\n";
                       document.getElementById(
                         "analysisengineoutput",
-                      ).innerText = analysis_engine_output;
+                      ).textContent = analysis_engine_output;
                       scrollOutput();
                     };
                     fge.analysis_engine.EvaluationUpdateCallBack = (msg) => {
@@ -4451,7 +4513,7 @@
                       analysis_engine_output += "\n▶▶ " + msg + "\n\n";
                       document.getElementById(
                         "analysisengineoutput",
-                      ).innerText = analysis_engine_output;
+                      ).textContent = analysis_engine_output;
                       scrollOutput();
                     };
                   }

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -433,7 +433,6 @@
     margin-left: 10px;
     font-size: 16px;
     height: 600px;
-    width: 800px;
   }
 
   #info #sannotation {
@@ -1214,6 +1213,19 @@
       return Array.from(newArr);
     }
 
+    //Throttle function, used to prevent lag when operating DOM objects.
+    function Throttle(func, wait) {
+      let timer = null;
+      return function () {
+        if (!timer) {
+          timer = setTimeout(() => {
+            func.apply(this, arguments);
+            timer = null;
+          }, wait);
+        }
+      };
+    }
+
     function getFileFromServer(url, doneCallback, errorCallback) {
       var xhr;
       function handleStateChange() {
@@ -1728,6 +1740,8 @@
       let previous_mover = "";
       let move_finish_timer_updating = false;
       let changing_variant_type = false;
+      let clear_log = true;
+      let throttle_threshold = 400; //in milliseconds, increase this if the GUI lags
       let timer;
 
       let variants = [];
@@ -2545,6 +2559,11 @@
         const threadnum = $("#threads").value;
         const hashsize = $("#hash").value;
         const multipleprincipalvariation = $("#multipv").value;
+        const whiteengineoutput = document.getElementById("whiteengineoutput");
+        const blackengineoutput = document.getElementById("blackengineoutput");
+        const analysisengineoutput = document.getElementById(
+          "analysisengineoutput",
+        );
         let whitedepthv = parseInt($("#whitedepth").value);
         let whitemovetimev = parseInt($("#whitemovetime").value);
         let whitenodesv = parseInt($("#whitenodes").value);
@@ -2688,9 +2707,6 @@
         stockfish.postMessage(`isready`);
 
         const stm = $("#label-stm").innerText;
-        const clear_log = document.getElementById(
-          "clearlogonstartthinking",
-        ).checked;
         play_move =
           (play_white && stm == "white") ||
           (play_black && stm == "black") ||
@@ -2700,6 +2716,7 @@
             if (fge.analysis_engine) {
               if (fge.analysis_engine.IsUsing) {
                 if (clear_log) {
+                  analysisengineoutput.textContent = "";
                   analysis_engine_output = "";
                 }
                 fge.analysis_engine.IsAnalysisEngine = true;
@@ -2758,6 +2775,7 @@
                   );
                 } else {
                   if (clear_log) {
+                    whiteengineoutput.textContent = "";
                     first_engine_output = "";
                   }
                   fge.first_engine.StartThinking(
@@ -2794,6 +2812,7 @@
                   fge.second_engine.PonderMove != "0000"
                 ) {
                   if (clear_log) {
+                    blackengineoutput.textContent = "";
                     second_engine_output = "";
                   }
                   fge.second_engine.StartThinking(
@@ -2848,6 +2867,7 @@
                   );
                 } else {
                   if (clear_log) {
+                    blackengineoutput.textContent = "";
                     second_engine_output = "";
                   }
                   fge.second_engine.StartThinking(
@@ -2884,6 +2904,7 @@
                   fge.first_engine.PonderMove != "0000"
                 ) {
                   if (clear_log) {
+                    whiteengineoutput.textContent = "";
                     first_engine_output = "";
                   }
                   fge.first_engine.StartThinking(
@@ -4460,17 +4481,20 @@
                 hidden: true,
                 onclick: () => {
                   if (fge.first_engine) {
+                    const OutputUpdateThrottleFunction = Throttle(() => {
+                      document.getElementById(
+                        "whiteengineoutput",
+                      ).textContent += first_engine_output;
+                      first_engine_output = "";
+                      scrollOutput();
+                    }, throttle_threshold);
                     fge.first_engine.OutputUpdateCallBack = (color, msg) => {
                       first_engine_output += "◀◀ " + msg + "\n";
-                      document.getElementById("whiteengineoutput").textContent =
-                        first_engine_output;
-                      scrollOutput();
+                      OutputUpdateThrottleFunction();
                     };
                     fge.first_engine.SendMessageCallBack = (msg) => {
                       first_engine_output += "\n▶▶ " + msg + "\n\n";
-                      document.getElementById("whiteengineoutput").textContent =
-                        first_engine_output;
-                      scrollOutput();
+                      OutputUpdateThrottleFunction();
                     };
                     fge.first_engine.OnErrorMessageCallBack = (msg) => {
                       if (during_play) {
@@ -4479,17 +4503,20 @@
                     };
                   }
                   if (fge.second_engine) {
+                    const OutputUpdateThrottleFunction = Throttle(() => {
+                      document.getElementById(
+                        "blackengineoutput",
+                      ).textContent += second_engine_output;
+                      second_engine_output = "";
+                      scrollOutput();
+                    }, throttle_threshold);
                     fge.second_engine.OutputUpdateCallBack = (color, msg) => {
                       second_engine_output += "◀◀ " + msg + "\n";
-                      document.getElementById("blackengineoutput").textContent =
-                        second_engine_output;
-                      scrollOutput();
+                      OutputUpdateThrottleFunction();
                     };
                     fge.second_engine.SendMessageCallBack = (msg) => {
                       second_engine_output += "\n▶▶ " + msg + "\n\n";
-                      document.getElementById("blackengineoutput").textContent =
-                        second_engine_output;
-                      scrollOutput();
+                      OutputUpdateThrottleFunction();
                     };
                     fge.second_engine.OnErrorMessageCallBack = (msg) => {
                       if (during_play) {
@@ -4498,12 +4525,16 @@
                     };
                   }
                   if (fge.analysis_engine) {
-                    fge.analysis_engine.OutputUpdateCallBack = (color, msg) => {
-                      analysis_engine_output += "◀◀ " + msg + "\n";
+                    const OutputUpdateThrottleFunction = Throttle(() => {
                       document.getElementById(
                         "analysisengineoutput",
-                      ).textContent = analysis_engine_output;
+                      ).textContent += analysis_engine_output;
+                      analysis_engine_output = "";
                       scrollOutput();
+                    }, throttle_threshold);
+                    fge.analysis_engine.OutputUpdateCallBack = (color, msg) => {
+                      analysis_engine_output += "◀◀ " + msg + "\n";
+                      OutputUpdateThrottleFunction();
                     };
                     fge.analysis_engine.EvaluationUpdateCallBack = (msg) => {
                       document.getElementById("engineoutputline").value = msg;
@@ -4511,10 +4542,7 @@
                     };
                     fge.analysis_engine.SendMessageCallBack = (msg) => {
                       analysis_engine_output += "\n▶▶ " + msg + "\n\n";
-                      document.getElementById(
-                        "analysisengineoutput",
-                      ).textContent = analysis_engine_output;
-                      scrollOutput();
+                      OutputUpdateThrottleFunction();
                     };
                   }
                   scrollOutput();
@@ -5130,17 +5158,17 @@
                 m(
                   "pre#whiteengineoutput",
                   { hidden: true },
-                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.",
+                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.\n\n",
                 ),
                 m(
                   "pre#blackengineoutput",
                   { hidden: true },
-                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.",
+                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.\n\n",
                 ),
                 m(
                   "pre#analysisengineoutput",
                   { hidden: true },
-                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.",
+                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.\n\n",
                 ),
               ]),
               m("div#enginecmddiv", [
@@ -5230,6 +5258,10 @@
                   "label#label-clearlogonstartthinking",
                   m("input[type=checkbox]#clearlogonstartthinking", {
                     disabled: !is_ready,
+                    checked: clear_log,
+                    onclick: () => {
+                      clear_log = !clear_log;
+                    },
                   }),
                   "Clear Log On Start Thinking",
                 ),
@@ -5240,13 +5272,13 @@
                       first_engine_output = "";
                       second_engine_output = "";
                       analysis_engine_output = "";
-                      document.getElementById("whiteengineoutput").innerText =
+                      document.getElementById("whiteengineoutput").textContent =
                         "";
-                      document.getElementById("blackengineoutput").innerText =
+                      document.getElementById("blackengineoutput").textContent =
                         "";
                       document.getElementById(
                         "analysisengineoutput",
-                      ).innerText = "";
+                      ).textContent = "";
                       scrollOutput();
                     },
                   },

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1288,6 +1288,9 @@
       if (typeof FileReader === "undefined") {
         return false;
       }
+      if (typeof WebSocket === "undefined") {
+        return false;
+      }
       return true;
     };
 

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -430,9 +430,10 @@
 
   #info {
     padding: 10px;
-    margin-left: 20px;
+    margin-left: 10px;
     font-size: 16px;
     height: 600px;
+    width: 800px;
   }
 
   #info #sannotation {
@@ -558,7 +559,7 @@
     border: 1px solid #ddd;
   }
 
-  #info #enginecmddiv #sendenginecmd {
+  #info #enginecmddiv button {
     display: inline-block;
     padding: 3px 6px 3px 6px;
     background: #888;
@@ -568,21 +569,21 @@
     cursor: pointer;
   }
 
-  #info #enginecmddiv #sendenginecmd:hover {
+  #info #enginecmddiv button:hover {
     background: #aaa;
   }
 
-  #info #enginecmddiv #sendenginecmd:disabled {
+  #info #enginecmddiv button:disabled {
     background: #ccc;
     color: #000;
   }
 
-  #info #enginecmddiv #sendenginecmd:active {
+  #info #enginecmddiv button:active {
     background: #000;
   }
 
   #info #enginecmddiv #targetengine {
-    width: 200px;
+    width: 150px;
     background: #eee;
   }
 
@@ -2166,7 +2167,7 @@
         }
         if (cmd[0] == "ponderhit") {
           window.alert(
-            "Cannot send this command: Fairyground does not allow engine pondering.",
+            "Cannot send this command: Engine ponder hit is only allowed to be sent by the GUI.",
           );
           return;
         }
@@ -2640,6 +2641,9 @@
         stockfish.postMessage(`isready`);
 
         const stm = $("#label-stm").innerText;
+        const clear_log = document.getElementById(
+          "clearlogonstartthinking",
+        ).checked;
         play_move =
           (play_white && stm == "white") ||
           (play_black && stm == "black") ||
@@ -2648,7 +2652,9 @@
           if (analysis_mode) {
             if (fge.analysis_engine) {
               if (fge.analysis_engine.IsUsing) {
-                analysis_engine_output = "";
+                if (clear_log) {
+                  analysis_engine_output = "";
+                }
                 fge.analysis_engine.IsAnalysisEngine = true;
                 fge.analysis_engine.StartThinking(
                   stm,
@@ -2702,7 +2708,9 @@
                     "",
                   );
                 } else {
-                  first_engine_output = "";
+                  if (clear_log) {
+                    first_engine_output = "";
+                  }
                   fge.first_engine.StartThinking(
                     stm,
                     advanced_time_control,
@@ -2736,7 +2744,9 @@
                   fge.second_engine.Ponder &&
                   fge.second_engine.PonderMove != "0000"
                 ) {
-                  second_engine_output = "";
+                  if (clear_log) {
+                    second_engine_output = "";
+                  }
                   fge.second_engine.StartThinking(
                     stm,
                     true,
@@ -2786,7 +2796,9 @@
                     "",
                   );
                 } else {
-                  second_engine_output = "";
+                  if (clear_log) {
+                    second_engine_output = "";
+                  }
                   fge.second_engine.StartThinking(
                     stm,
                     advanced_time_control,
@@ -2820,7 +2832,9 @@
                   fge.first_engine.Ponder &&
                   fge.first_engine.PonderMove != "0000"
                 ) {
-                  first_engine_output = "";
+                  if (clear_log) {
+                    first_engine_output = "";
+                  }
                   fge.first_engine.StartThinking(
                     stm,
                     true,
@@ -4395,7 +4409,13 @@
                 onclick: () => {
                   if (fge.first_engine) {
                     fge.first_engine.OutputUpdateCallBack = (color, msg) => {
-                      first_engine_output += msg + "\n";
+                      first_engine_output += "◀◀ " + msg + "\n";
+                      document.getElementById("whiteengineoutput").innerText =
+                        first_engine_output;
+                      scrollOutput();
+                    };
+                    fge.first_engine.SendMessageCallBack = (msg) => {
+                      first_engine_output += "\n▶▶ " + msg + "\n\n";
                       document.getElementById("whiteengineoutput").innerText =
                         first_engine_output;
                       scrollOutput();
@@ -4403,7 +4423,13 @@
                   }
                   if (fge.second_engine) {
                     fge.second_engine.OutputUpdateCallBack = (color, msg) => {
-                      second_engine_output += msg + "\n";
+                      second_engine_output += "◀◀ " + msg + "\n";
+                      document.getElementById("blackengineoutput").innerText =
+                        second_engine_output;
+                      scrollOutput();
+                    };
+                    fge.second_engine.SendMessageCallBack = (msg) => {
+                      second_engine_output += "\n▶▶ " + msg + "\n\n";
                       document.getElementById("blackengineoutput").innerText =
                         second_engine_output;
                       scrollOutput();
@@ -4411,7 +4437,7 @@
                   }
                   if (fge.analysis_engine) {
                     fge.analysis_engine.OutputUpdateCallBack = (color, msg) => {
-                      analysis_engine_output += msg + "\n";
+                      analysis_engine_output += "◀◀ " + msg + "\n";
                       document.getElementById(
                         "analysisengineoutput",
                       ).innerText = analysis_engine_output;
@@ -4420,6 +4446,13 @@
                     fge.analysis_engine.EvaluationUpdateCallBack = (msg) => {
                       document.getElementById("engineoutputline").value = msg;
                       document.getElementById("engineoutputline").click();
+                    };
+                    fge.analysis_engine.SendMessageCallBack = (msg) => {
+                      analysis_engine_output += "\n▶▶ " + msg + "\n\n";
+                      document.getElementById(
+                        "analysisengineoutput",
+                      ).innerText = analysis_engine_output;
+                      scrollOutput();
                     };
                   }
                   scrollOutput();
@@ -5032,9 +5065,21 @@
               m("p#label-pgn"),
               m("div#output2", { onupdate: scrollOutput }, [
                 m("pre#fsfoutput", output2),
-                m("pre#whiteengineoutput", { hidden: true }, ""),
-                m("pre#blackengineoutput", { hidden: true }, ""),
-                m("pre#analysisengineoutput", { hidden: true }, ""),
+                m(
+                  "pre#whiteengineoutput",
+                  { hidden: true },
+                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.",
+                ),
+                m(
+                  "pre#blackengineoutput",
+                  { hidden: true },
+                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.",
+                ),
+                m(
+                  "pre#analysisengineoutput",
+                  { hidden: true },
+                  "This is the console where you can see the message communication.\nLines start with ▶▶ are the messages sent to the engine.\nLines start with ◀◀ are the messages received from the engine.",
+                ),
               ]),
               m("div#enginecmddiv", [
                 m("input#enginecmd", {
@@ -5118,6 +5163,32 @@
                     },
                   },
                   "SEND",
+                ),
+                m(
+                  "label#label-clearlogonstartthinking",
+                  m("input[type=checkbox]#clearlogonstartthinking", {
+                    disabled: !is_ready,
+                  }),
+                  "Clear Log On Start Thinking",
+                ),
+                m(
+                  "button",
+                  {
+                    onclick: () => {
+                      first_engine_output = "";
+                      second_engine_output = "";
+                      analysis_engine_output = "";
+                      document.getElementById("whiteengineoutput").innerText =
+                        "";
+                      document.getElementById("blackengineoutput").innerText =
+                        "";
+                      document.getElementById(
+                        "analysisengineoutput",
+                      ).innerText = "";
+                      scrollOutput();
+                    },
+                  },
+                  "Clear Logs",
                 ),
               ]),
             ]),

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -5022,82 +5022,124 @@
               ]),
             ]),
             m("div#info", [
-              m("select#sannotation", [
-                m("option", { value: "" }, "--Select Notation System--"),
-                m(
-                  "option",
-                  { value: "DEFAULT" },
-                  "Standard/Short Algebraic Notation Without Piece Type Omission (DEFAULT)",
-                ),
-                m(
-                  "option",
-                  { value: "SAN" },
-                  "Standard/Short Algebraic Notation (SAN)",
-                ),
-                m("option", { value: "LAN" }, "Long Algebraic Notation (LAN)"),
-                m(
-                  "option",
-                  { value: "SHOGI_HOSKING" },
-                  "Shogi Hosking Notation (SHOGI_HOSKING)",
-                ),
-                m(
-                  "option",
-                  { value: "SHOGI_HODGES" },
-                  "Shogi George Hodges Notation (SHOGI_HODGES)",
-                ),
-                m(
-                  "option",
-                  { value: "SHOGI_HODGES_NUMBER" },
-                  "Shogi George Hodges Number-only Notation (SHOGI_HODGES_NUMBER)",
-                ),
-                m("option", { value: "JANGGI" }, "Janggi Notation (JANGGI)"),
-                m(
-                  "option",
-                  { value: "XIANGQI_WXF" },
-                  "World Xiangqi Federation Notation (XIANGQI_WXF)",
-                ),
-                m(
-                  "option",
-                  { value: "THAI_SAN" },
-                  "Thai Standard/Short Algebraic Notation (THAI_SAN)",
-                ),
-                m(
-                  "option",
-                  { value: "THAI_LAN" },
-                  "Thai Long Algebraic Notation (THAI_LAN)",
-                ),
-                m(
-                  "option",
-                  { value: "FEN" },
-                  "Forsyth–Edwards Notation (Fairy-Stockfish) (FEN)",
-                ),
-                m("option", { value: "PGN" }, "Portable Game Notation (PGN)"),
-                m(
-                  "option",
-                  { value: "EPD" },
-                  "Extended Position Description (EPD)",
-                ),
-                m(
-                  "option",
-                  { value: "FEN+UCIMOVE" },
-                  "Forsyth–Edwards Notation (Fairy-Stockfish) and UCI Moves (FEN+UCIMOVE)",
-                ),
-                m(
-                  "option",
-                  { value: "FEN+USIMOVE" },
-                  "Forsyth–Edwards Notation (Fairy-Stockfish) and USI Moves (FEN+USIMOVE)",
-                ),
-                m(
-                  "option",
-                  { value: "FEN+UCCIMOVE" },
-                  "Forsyth–Edwards Notation (Fairy-Stockfish) and UCCI (CECP) Moves (FEN+UCCIMOVE)",
-                ),
-                m(
-                  "option",
-                  { value: "SFEN+USIMOVE" },
-                  "Shogi Forsyth–Edwards Notation and USI Moves (SFEN+USIMOVE)",
-                ),
-              ]),
+              m(
+                "select#sannotation",
+                {
+                  onchange: () => {
+                    const dropdownnotation =
+                      document.getElementById("sannotation");
+                    const evalbar = document.getElementById("evalbar");
+                    const evalbarprogress =
+                      document.getElementById("evalbarprogress");
+                    const cp = document.getElementById("cp");
+                    if (dropdownnotation.selectedIndex < 0) {
+                      evalbar.style.backgroundColor = "#111111";
+                      evalbarprogress.style.backgroundColor = "#eeeeee";
+                      cp.style.color = "orange";
+                      return;
+                    }
+                    const value =
+                      dropdownnotation[dropdownnotation.selectedIndex].value;
+                    if (/xiangqi|ucci/i.test(value)) {
+                      evalbar.style.backgroundColor = "black";
+                      evalbarprogress.style.backgroundColor = "red";
+                      cp.style.color = "white";
+                    } else if (/shogi|usi/i.test(value)) {
+                      evalbar.style.backgroundColor = "#eeeeee";
+                      evalbarprogress.style.backgroundColor = "#111111";
+                      cp.style.color = "orange";
+                    } else if (/janggi/i.test(value)) {
+                      evalbar.style.backgroundColor = "red";
+                      evalbarprogress.style.backgroundColor = "blue";
+                      cp.style.color = "white";
+                    } else {
+                      evalbar.style.backgroundColor = "#111111";
+                      evalbarprogress.style.backgroundColor = "#eeeeee";
+                      cp.style.color = "orange";
+                    }
+                  },
+                },
+                [
+                  m("option", { value: "" }, "--Select Notation System--"),
+                  m(
+                    "option",
+                    { value: "DEFAULT" },
+                    "Standard/Short Algebraic Notation Without Piece Type Omission (DEFAULT)",
+                  ),
+                  m(
+                    "option",
+                    { value: "SAN" },
+                    "Standard/Short Algebraic Notation (SAN)",
+                  ),
+                  m(
+                    "option",
+                    { value: "LAN" },
+                    "Long Algebraic Notation (LAN)",
+                  ),
+                  m(
+                    "option",
+                    { value: "SHOGI_HOSKING" },
+                    "Shogi Hosking Notation (SHOGI_HOSKING)",
+                  ),
+                  m(
+                    "option",
+                    { value: "SHOGI_HODGES" },
+                    "Shogi George Hodges Notation (SHOGI_HODGES)",
+                  ),
+                  m(
+                    "option",
+                    { value: "SHOGI_HODGES_NUMBER" },
+                    "Shogi George Hodges Number-only Notation (SHOGI_HODGES_NUMBER)",
+                  ),
+                  m("option", { value: "JANGGI" }, "Janggi Notation (JANGGI)"),
+                  m(
+                    "option",
+                    { value: "XIANGQI_WXF" },
+                    "World Xiangqi Federation Notation (XIANGQI_WXF)",
+                  ),
+                  m(
+                    "option",
+                    { value: "THAI_SAN" },
+                    "Thai Standard/Short Algebraic Notation (THAI_SAN)",
+                  ),
+                  m(
+                    "option",
+                    { value: "THAI_LAN" },
+                    "Thai Long Algebraic Notation (THAI_LAN)",
+                  ),
+                  m(
+                    "option",
+                    { value: "FEN" },
+                    "Forsyth–Edwards Notation (Fairy-Stockfish) (FEN)",
+                  ),
+                  m("option", { value: "PGN" }, "Portable Game Notation (PGN)"),
+                  m(
+                    "option",
+                    { value: "EPD" },
+                    "Extended Position Description (EPD)",
+                  ),
+                  m(
+                    "option",
+                    { value: "FEN+UCIMOVE" },
+                    "Forsyth–Edwards Notation (Fairy-Stockfish) and UCI Moves (FEN+UCIMOVE)",
+                  ),
+                  m(
+                    "option",
+                    { value: "FEN+USIMOVE" },
+                    "Forsyth–Edwards Notation (Fairy-Stockfish) and USI Moves (FEN+USIMOVE)",
+                  ),
+                  m(
+                    "option",
+                    { value: "FEN+UCCIMOVE" },
+                    "Forsyth–Edwards Notation (Fairy-Stockfish) and UCCI (CECP) Moves (FEN+UCCIMOVE)",
+                  ),
+                  m(
+                    "option",
+                    { value: "SFEN+USIMOVE" },
+                    "Shogi Forsyth–Edwards Notation and USI Moves (SFEN+USIMOVE)",
+                  ),
+                ],
+              ),
               m("p#positioninfo", ""),
               m("div#timers", { hidden: !advanced_time_control }, [
                 m("div#whitetimer", [

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1007,6 +1007,22 @@
     border: double #ffffff;
   }
 
+  #fsfoutput {
+    font-family: Consolas;
+  }
+
+  #whiteengineoutput {
+    font-family: Consolas;
+  }
+
+  #blackengineoutput {
+    font-family: Consolas;
+  }
+
+  #analysisengineoutput {
+    font-family: Consolas;
+  }
+
   #enginesettingspopup {
     display: none;
     position: fixed;

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1935,7 +1935,11 @@
         play_move = false;
         stop(true);
         const variant = $("#dropdown-variant").value;
-        stockfish.postMessage(`setoption name UCI_Variant value ${variant}`);
+        if (variant == "") {
+          stockfish.postMessage(`setoption name UCI_Variant value chess`);
+        } else {
+          stockfish.postMessage(`setoption name UCI_Variant value ${variant}`);
+        }
         stockfish.postMessage(`position startpos`);
         if (fge.WebSocketStatus == "CONNECTED") {
           if (fge.first_engine) {

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1745,7 +1745,7 @@
                 fge.WebSocketStatus = "ERROR";
                 const binenginediv = document.getElementById("binengineinput");
                 if (binenginediv) {
-                  binenginediv.hidden = true;
+                  binenginediv.style.display = "none";
                 }
                 fge.first_engine = null;
                 fge.second_engine = null;
@@ -1780,7 +1780,7 @@
                   const binenginediv =
                     document.getElementById("binengineinput");
                   if (binenginediv) {
-                    binenginediv.hidden = true;
+                    binenginediv.style.display = "none";
                   }
                   fge.first_engine = null;
                   fge.second_engine = null;
@@ -1811,7 +1811,7 @@
               fge.WebSocketStatus = "CLOSED";
               const binenginediv = document.getElementById("binengineinput");
               if (binenginediv) {
-                binenginediv.hidden = true;
+                binenginediv.style.display = "none";
               }
               fge.first_engine = null;
               fge.second_engine = null;
@@ -1832,7 +1832,7 @@
               console.error(event);
               const binenginediv = document.getElementById("binengineinput");
               if (binenginediv) {
-                binenginediv.hidden = true;
+                binenginediv.style.display = "none";
               }
               fge.first_engine = null;
               fge.second_engine = null;
@@ -1864,7 +1864,7 @@
           );
           const binenginediv = document.getElementById("binengineinput");
           if (binenginediv) {
-            binenginediv.hidden = true;
+            binenginediv.style.display = "none";
           }
           fge.first_engine = null;
           fge.second_engine = null;
@@ -1881,7 +1881,7 @@
         fge.WebSocketStatus = "ERROR";
         const binenginediv = document.getElementById("binengineinput");
         if (binenginediv) {
-          binenginediv.hidden = true;
+          binenginediv.style.display = "none";
         }
         fge.first_engine = null;
         fge.second_engine = null;
@@ -4058,88 +4058,92 @@
               "◀️Undo",
             ),
           ]),
-          m("div#binengineinput", { hidden: during_play }, [
-            m(
-              "button",
-              {
-                onclick: () => {
-                  fge.ShowEngineManagementUI(engine_list, fge.ws);
+          m(
+            "div#binengineinput",
+            { hidden: during_play || fge.WebSocketStatus != "CONNECTED" },
+            [
+              m(
+                "button",
+                {
+                  onclick: () => {
+                    fge.ShowEngineManagementUI(engine_list, fge.ws);
+                  },
                 },
-              },
-              "Engine Management",
-            ),
-            m("div#whiteenginesettings", [
-              m("p", "1st binary engine settings:"),
-              m("input[type=number]#whitedepth", {
-                placeholder: "Depth",
-                disabled:
-                  !is_ready ||
-                  fge.WebSocketStatus != "CONNECTED" ||
-                  analysis_mode,
-                min: 1,
-              }),
-              m("input[type=number]#whitemovetime", {
-                placeholder: "Movetime",
-                disabled:
-                  !is_ready ||
-                  fge.WebSocketStatus != "CONNECTED" ||
-                  analysis_mode,
-                min: 0,
-              }),
-              m("input[type=number]#whitenodes", {
-                placeholder: "Nodes",
-                disabled:
-                  !is_ready ||
-                  fge.WebSocketStatus != "CONNECTED" ||
-                  analysis_mode,
-                min: 1,
-              }),
-              m(
-                "p#whiteunsupportedvariant",
-                { hidden: true },
-                "1st engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+                "Engine Management",
               ),
-            ]),
-            m("div#blackenginesettings", [
-              m("p", "2nd binary engine settings:"),
-              m("input[type=number]#blackdepth", {
-                placeholder: "Depth",
-                disabled:
-                  !is_ready ||
-                  fge.WebSocketStatus != "CONNECTED" ||
-                  analysis_mode,
-                min: 1,
-              }),
-              m("input[type=number]#blackmovetime", {
-                placeholder: "Movetime",
-                disabled:
-                  !is_ready ||
-                  fge.WebSocketStatus != "CONNECTED" ||
-                  analysis_mode,
-                min: 0,
-              }),
-              m("input[type=number]#blacknodes", {
-                placeholder: "Nodes",
-                disabled:
-                  !is_ready ||
-                  fge.WebSocketStatus != "CONNECTED" ||
-                  analysis_mode,
-                min: 1,
-              }),
-              m(
-                "p#blackunsupportedvariant",
-                { hidden: true },
-                "2nd engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
-              ),
-            ]),
-            m("div#analysisenginesettings", [
-              m(
-                "p#analysisunsupportedvariant",
-                { hidden: true },
-                "Analysis engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
-              ),
-            ]),
-          ]),
+              m("div#whiteenginesettings", [
+                m("p", "1st binary engine settings:"),
+                m("input[type=number]#whitedepth", {
+                  placeholder: "Depth",
+                  disabled:
+                    !is_ready ||
+                    fge.WebSocketStatus != "CONNECTED" ||
+                    analysis_mode,
+                  min: 1,
+                }),
+                m("input[type=number]#whitemovetime", {
+                  placeholder: "Movetime",
+                  disabled:
+                    !is_ready ||
+                    fge.WebSocketStatus != "CONNECTED" ||
+                    analysis_mode,
+                  min: 0,
+                }),
+                m("input[type=number]#whitenodes", {
+                  placeholder: "Nodes",
+                  disabled:
+                    !is_ready ||
+                    fge.WebSocketStatus != "CONNECTED" ||
+                    analysis_mode,
+                  min: 1,
+                }),
+                m(
+                  "p#whiteunsupportedvariant",
+                  { hidden: true },
+                  "1st engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+                ),
+              ]),
+              m("div#blackenginesettings", [
+                m("p", "2nd binary engine settings:"),
+                m("input[type=number]#blackdepth", {
+                  placeholder: "Depth",
+                  disabled:
+                    !is_ready ||
+                    fge.WebSocketStatus != "CONNECTED" ||
+                    analysis_mode,
+                  min: 1,
+                }),
+                m("input[type=number]#blackmovetime", {
+                  placeholder: "Movetime",
+                  disabled:
+                    !is_ready ||
+                    fge.WebSocketStatus != "CONNECTED" ||
+                    analysis_mode,
+                  min: 0,
+                }),
+                m("input[type=number]#blacknodes", {
+                  placeholder: "Nodes",
+                  disabled:
+                    !is_ready ||
+                    fge.WebSocketStatus != "CONNECTED" ||
+                    analysis_mode,
+                  min: 1,
+                }),
+                m(
+                  "p#blackunsupportedvariant",
+                  { hidden: true },
+                  "2nd engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+                ),
+              ]),
+              m("div#analysisenginesettings", [
+                m(
+                  "p#analysisunsupportedvariant",
+                  { hidden: true },
+                  "Analysis engine does not support this variant. In browser Fairy-Stockfish will be used instead.",
+                ),
+              ]),
+            ],
+          ),
           m("div#input2", { hidden: during_play }, [
             m("p", "Settings:"),
             m("input[type=number]#depth", {

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -693,7 +693,6 @@
     width: 25%;
     padding: 2px 0 2px 6px;
     border: 1px solid #ddd;
-    border-right: 0;
   }
 
   #boardsetupsettings2 #currentmovenum:invalid {
@@ -717,10 +716,9 @@
     width: 35%;
     padding: 2px 0 2px 6px;
     border: 1px solid #ddd;
-    border-right: 0;
   }
 
-  #boardsetupsettings2 #enpassantfile:invalid {
+  #boardsetupsettings2 #enpassantrank:invalid {
     background: #ff9e9e;
     border: 3px solid #f00;
   }
@@ -729,7 +727,6 @@
     width: 60%;
     padding: 2px 0 2px 6px;
     border: 1px solid #ddd;
-    border-right: 0;
   }
 
   #advancedtimesettings {

--- a/public/index.html
+++ b/public/index.html
@@ -32,6 +32,7 @@
       const go = advpage.getElementById("go");
       const stop = advpage.getElementById("stop");
       const label_analysis = advpage.getElementById("label-analysis");
+      const label_boardsetup = advpage.getElementById("label-boardsetup");
       const output2 = advpage.getElementById("output2");
       const currentboardfen = advpage.getElementById("currentboardfen");
       const label_pgn = advpage.getElementById("label-pgn");
@@ -54,6 +55,7 @@
       const whitetimegain = advpage.getElementById("whitetimegain");
       const blacktimegain = advpage.getElementById("blacktimegain");
       const enginecmddiv = advpage.getElementById("enginecmddiv");
+      const dropdownNotationSystem = advpage.getElementById("sannotation");
       pagetitle.innerHTML = "Play against Fairy-Stockfish";
       fen.style.display = "none";
       move.style.display = "none";
@@ -67,6 +69,7 @@
       go.style.display = "none";
       stop.style.display = "none";
       label_analysis.style.display = "none";
+      label_boardsetup.style.display = "none";
       output2.style.display = "none";
       currentboardfen.style.display = "none";
       label_pgn.style.display = "none";
@@ -89,6 +92,7 @@
       whitetimemargin.style.display = "none";
       blacktimemargin.style.display = "none";
       enginecmddiv.style.display = "none";
+      dropdownNotationSystem.style.display = "none";
     };
   </script>
 </body>

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -36,8 +36,12 @@ shoshogi|Shogi Variants|Sho Shogi|A new piece called Drunk Elephant is introduce
 
 xiangqi|Xiangqi Variants|Xiangqi|Chinese Chess, one of the oldest and most played board games in the world.
 manchu|Xiangqi Variants|Manchu Xiangqi|Xiangqi variant where one side has a chariot that can also move as a cannon or horse.
-janggi|Xiangqi Variants|Janggi|Korean Chess, similar to Xiangqi but plays much differently. Tournament rules are used.
 minixiangqi|Xiangqi Variants|Mini Xiangqi|Compact version of Xiangqi played on a 7x7 board without a river.
+
+janggi|Janggi Variants|Janggi|Korean Chess, similar to Xiangqi but plays much differently. Tournament rules are used.
+janggicasual|Janggi Variants|Janggi Casual|Korean Chess, similar to Xiangqi but plays much differently. Casual rules are used.
+janggimodern|Janggi Variants|Janggi Modern|Korean Chess, similar to Xiangqi but plays much differently. Modern rules are used.
+janggitraditional|Janggi Variants|Janggi Traditional|Korean Chess, similar to Xiangqi but plays much differently. Traditional rules are used.
 
 capablanca|Fairy Variants|Capablanca Chess|Play with the hybrid pieces, archbishop (B+N) and chancellor (R+N), on a 10x8 board.
 capahouse|Fairy Variants|Capablanca House|Capablanca with Crazyhouse drop rules.

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -21,15 +21,16 @@ knightmate|Chess Variants|Knight Mate|The king moves like a knight while the kni
 
 makruk|Makruk Variants|Makruk|Thai Chess. A game closely resembling the original Chaturanga. Similar to Chess but with a different queen and bishop.
 makpong|Makruk Variants|Makpong|Makruk variant where kings cannot move to escape out of check.
-cambodian|Makruk Variants|Cambodian Chess|Makruk with a few additional opening abilities.
+cambodian|Makruk Variants|Ouk Chatrang|Cambodian Chess. Makruk with a few additional opening abilities.
 sittuyin|Makruk Variants|Sittuyin|Burmese Chess. Similar to Makruk, but pieces are placed at the start of the match.
 asean|Makruk Variants|Asean|Makruk using the board/pieces from International Chess as well as pawn promotion rules.
 
 shogi|Shogi Variants|Shogi|Japanese Chess, the standard 9x9 version played today with drops and promotions.
 minishogi|Shogi Variants|Mini Shogi|5x5 Shogi for more compact and faster games. There are no knights or lances.
 kyotoshogi|Shogi Variants|Kyoto Shogi|A wild Shogi variant on a 5x5 board where pieces flip into a different piece after each move.
-dobutsu|Shogi Variants|Dobutsu|3x4 game with cute animals, designed to teach children how to play Shogi.
-gorogoroplus|Shogi Variants|Gorogoro+|5x6 Shogi designed to introduce tactics with the generals.
+dobutsu|Shogi Variants|Dobutsu Shogi|3x4 game with cute animals, designed to teach children how to play Shogi.
+gorogoro|Shogi Variants|Gorogoro Shogi|5x6 Shogi designed to introduce tactics with the generals.
+gorogoroplus|Shogi Variants|Gorogoro+ Shogi|5x6 Shogi designed to introduce tactics with the generals.
 torishogi|Shogi Variants|Tori Shogi|A confrontational 7x7 variant with unique pieces each named after different birds.
 shoshogi|Shogi Variants|Sho Shogi|A new piece called Drunk Elephant is introduced, which can promote to a new king. You can lose one of the 2 kings after the promotion.
 

--- a/src/BinaryEngineFeature.js
+++ b/src/BinaryEngineFeature.js
@@ -1190,7 +1190,8 @@ class Engine {
         if (typeof this.IsReadyCallBack == "function") {
           this.IsReadyCallBack();
         }
-      } else if (typeof this.EvaluationUpdateCallBack == "function") {
+      }
+      if (typeof this.EvaluationUpdateCallBack == "function") {
         if (/( upperbound )|( lowerbound )/.test(Message)) {
           return;
         }
@@ -1292,6 +1293,55 @@ class Engine {
             );
           }
           this.EvaluationUpdateCallBack(msglist.join(" ") + " pv " + moves);
+        } else if (Message.includes("bestmove")) {
+          let msglist = Message.split(" ");
+          let bestmove = msglist[1];
+          let ponder = "0000";
+          if (msglist[2] == "draw") {
+            ponder = msglist[4];
+          } else {
+            ponder = msglist[3];
+          }
+          if (this.Protocol == "USI") {
+            bestmove = convertUSImovestoUCImoves(
+              bestmove,
+              GetBoardWidth(),
+              GetBoardHeight(),
+            );
+          } else if (
+            this.Protocol == "UCCI" ||
+            this.Protocol == "UCI_CYCLONE"
+          ) {
+            bestmove = convertUCCImovestoUCImoves(
+              bestmove,
+              GetBoardWidth(),
+              GetBoardHeight(),
+            );
+          }
+          if (ponder) {
+            if (this.Protocol == "USI") {
+              ponder = convertUSImovestoUCImoves(
+                ponder,
+                GetBoardWidth(),
+                GetBoardHeight(),
+              );
+            } else if (
+              this.Protocol == "UCCI" ||
+              this.Protocol == "UCI_CYCLONE"
+            ) {
+              ponder = convertUCCImovestoUCImoves(
+                ponder,
+                GetBoardWidth(),
+                GetBoardHeight(),
+              );
+            }
+          } else {
+            ponder = "0000";
+          }
+          //console.log(`bestmove ${bestmove} ponder ${ponder}`);
+          this.EvaluationUpdateCallBack(
+            `bestmove ${bestmove} ponder ${ponder}`,
+          );
         }
       }
     } else if (this.IsLoading) {

--- a/src/BinaryEngineFeature.js
+++ b/src/BinaryEngineFeature.js
@@ -1,0 +1,2997 @@
+﻿function ConvertFENtoSFEN(fen) {
+  if (typeof fen != "string") {
+    return null;
+  }
+  let fen_list = fen.trim().split(" ");
+  let sfen = ["", "", "", ""];
+  if (fen_list.length != 6 && fen_list.length != 7) {
+    return null;
+  }
+  if (!fen_list[0].includes("[") || !fen_list[0].includes("]")) {
+    if (fen_list[0].indexOf("[") >= 0 || fen_list[0].indexOf("]") >= 0) {
+      return null;
+    }
+    sfen[0] = fen_list[0];
+    sfen[2] = "";
+  } else {
+    if (
+      fen_list[0].indexOf("[") > fen_list[0].indexOf("]") ||
+      fen_list[0].indexOf("]") < 0
+    ) {
+      return null;
+    }
+    sfen[0] = fen_list[0].substring(0, fen_list[0].indexOf("["));
+    sfen[2] = fen_list[0].substring(
+      fen_list[0].indexOf("[") + 1,
+      fen_list[0].indexOf("]"),
+    );
+  }
+  if (fen_list[1] == "w") {
+    sfen[1] = "b";
+  } else if (fen_list[1] == "b") {
+    sfen[1] = "w";
+  } else {
+    return null;
+  }
+  if (sfen[2].length == 0) {
+    sfen[2] = "-";
+  } else {
+    const charCount = sfen[2].split("").reduce((pre, cur) => {
+      if (cur in pre) {
+        pre[cur]++;
+      } else {
+        pre[cur] = 1;
+      }
+      return pre;
+    }, {});
+    sfen[2] = "";
+    let ch;
+    for (ch in charCount) {
+      if (charCount[ch] > 1) {
+        sfen[2] += ch.toString() + charCount[ch].toString();
+      } else {
+        sfen[2] += ch.toString();
+      }
+    }
+  }
+  if (parseInt(fen_list.at(-1)) != NaN) {
+    sfen[3] = parseInt(fen_list.at(-1)).toString();
+  } else {
+    return null;
+  }
+  return sfen.join(" ");
+}
+
+function convertUCImovestoUSImoves(moves, board_width, board_height) {
+  const chartoindex = [
+    "z",
+    "y",
+    "x",
+    "w",
+    "v",
+    "u",
+    "t",
+    "s",
+    "r",
+    "q",
+    "p",
+    "o",
+    "n",
+    "m",
+    "l",
+    "k",
+    "j",
+    "i",
+    "h",
+    "g",
+    "f",
+    "e",
+    "d",
+    "c",
+    "b",
+    "a",
+  ];
+  if (
+    typeof moves != "string" ||
+    typeof board_width != "number" ||
+    typeof board_height != "number"
+  ) {
+    return null;
+  }
+  if (board_width < 1 || board_height < 1) {
+    return null;
+  }
+  let movelist = moves.trim().split(" ");
+  try {
+    movelist.forEach((val, ind) => {
+      if (val.length < 1) {
+        return;
+      }
+      let newmovenotation = "";
+      let move = val;
+      let isPromotion = val.at(-1) == "+";
+      let isDemotion = val.at(-1) == "-";
+      let i = 0;
+      if (
+        !/^([+]?[A-Za-z]@)([a-z][0-9]+)[+-]?$/.test(val) &&
+        !/^([a-z][0-9]+){2}[+-]?$/.test(val)
+      ) {
+        throw SyntaxError;
+      }
+      if (isDemotion || isPromotion) {
+        move = move.substring(0, move.length - 1);
+      }
+      if (val.includes("@")) {
+        let atind = val.indexOf("@");
+        newmovenotation = val.replace("@", "*").substring(0, atind + 1);
+        move = move.substring(atind + 1);
+      }
+      let files = move.split(/[0-9]+/).filter((str) => {
+        return str != "";
+      });
+      let ranks = move.split(/[a-z]/).filter((str) => {
+        return str != "";
+      });
+      if (ranks.length != files.length) {
+        throw SyntaxError;
+      }
+      ranks.forEach((rval, rind) => {
+        if (parseInt(rval) < 1 || parseInt(rval) > board_height) {
+          throw RangeError;
+        }
+        ranks[rind] =
+          chartoindex[chartoindex.length - board_height + parseInt(rval) - 1];
+      });
+      files.forEach((fval, find) => {
+        if (fval < "a" || fval > chartoindex.at(-board_width)) {
+          throw RangeError;
+        }
+        files[find] = (
+          chartoindex.indexOf(fval) +
+          board_width -
+          chartoindex.length +
+          1
+        ).toString();
+      });
+      movelist[ind] = newmovenotation;
+      for (i = 0; i < ranks.length; i++) {
+        movelist[ind] += `${files[i]}${ranks[i]}`;
+      }
+      if (isDemotion) {
+        movelist[ind] += "-";
+      } else if (isPromotion) {
+        movelist[ind] += "+";
+      }
+    });
+  } catch {
+    return null;
+  }
+  return movelist.join(" ");
+}
+
+function convertUCImovestoUCCImoves(moves, board_width, board_height) {
+  const chartoindex = [
+    "z",
+    "y",
+    "x",
+    "w",
+    "v",
+    "u",
+    "t",
+    "s",
+    "r",
+    "q",
+    "p",
+    "o",
+    "n",
+    "m",
+    "l",
+    "k",
+    "j",
+    "i",
+    "h",
+    "g",
+    "f",
+    "e",
+    "d",
+    "c",
+    "b",
+    "a",
+  ];
+  if (
+    typeof moves != "string" ||
+    typeof board_width != "number" ||
+    typeof board_height != "number"
+  ) {
+    return null;
+  }
+  if (board_width < 1 || board_height < 1) {
+    return null;
+  }
+  let movelist = moves.trim().split(" ");
+  try {
+    movelist.forEach((val, ind) => {
+      if (val.length < 1) {
+        return;
+      }
+      let move = val;
+      let i = 0;
+      if (!/^([a-z][0-9]+){2}$/.test(val)) {
+        throw SyntaxError;
+      }
+      let files = move.split(/[0-9]+/).filter((str) => {
+        return str != "";
+      });
+      let ranks = move.split(/[a-z]/).filter((str) => {
+        return str != "";
+      });
+      if (ranks.length != files.length) {
+        throw SyntaxError;
+      }
+      ranks.forEach((rval, rind) => {
+        if (parseInt(rval) < 1 || parseInt(rval) > board_height) {
+          throw RangeError;
+        }
+        ranks[rind] = parseInt(rval) - 1;
+      });
+      files.forEach((fval, find) => {
+        if (fval < "a" || fval > chartoindex.at(-board_width)) {
+          throw RangeError;
+        }
+      });
+      movelist[ind] = "";
+      for (i = 0; i < ranks.length; i++) {
+        movelist[ind] += `${files[i]}${ranks[i]}`;
+      }
+    });
+  } catch {
+    return null;
+  }
+  return movelist.join(" ");
+}
+
+function convertUSImovestoUCImoves(moves, board_width, board_height) {
+  const chartoindex = [
+    "z",
+    "y",
+    "x",
+    "w",
+    "v",
+    "u",
+    "t",
+    "s",
+    "r",
+    "q",
+    "p",
+    "o",
+    "n",
+    "m",
+    "l",
+    "k",
+    "j",
+    "i",
+    "h",
+    "g",
+    "f",
+    "e",
+    "d",
+    "c",
+    "b",
+    "a",
+  ];
+  if (
+    typeof moves != "string" ||
+    typeof board_width != "number" ||
+    typeof board_height != "number"
+  ) {
+    return null;
+  }
+  if (board_width < 1 || board_height < 1) {
+    return null;
+  }
+  let movelist = moves.trim().split(" ");
+  try {
+    movelist.forEach((val, ind) => {
+      if (val.length < 1) {
+        return;
+      }
+      let newmovenotation = "";
+      let move = val;
+      let isPromotion = val.at(-1) == "+";
+      let isDemotion = val.at(-1) == "-";
+      let i = 0;
+      if (
+        !/^([+]?[A-Za-z]\*)([0-9]+[a-z])[+-]?$/.test(val) &&
+        !/^([0-9]+[a-z]){2}[+-]?$/.test(val)
+      ) {
+        throw SyntaxError;
+      }
+      if (isDemotion || isPromotion) {
+        move = move.substring(0, move.length - 1);
+      }
+      if (val.includes("*")) {
+        let atind = val.indexOf("*");
+        newmovenotation = val.replace("*", "@").substring(0, atind + 1);
+        move = move.substring(atind + 1);
+      }
+      let files = move.split(/[a-z]/).filter((str) => {
+        return str != "";
+      });
+      let ranks = move.split(/[0-9]+/).filter((str) => {
+        return str != "";
+      });
+      if (ranks.length != files.length) {
+        throw SyntaxError;
+      }
+      ranks.forEach((rval, rind) => {
+        if (rval < "a" || rval > chartoindex.at(-board_width)) {
+          throw RangeError;
+        }
+        ranks[rind] = (
+          chartoindex.indexOf(rval) +
+          board_width -
+          chartoindex.length +
+          1
+        ).toString();
+      });
+      files.forEach((fval, find) => {
+        if (parseInt(fval) < 1 || parseInt(fval) > board_height) {
+          throw RangeError;
+        }
+        files[find] =
+          chartoindex[chartoindex.length - board_height + parseInt(fval) - 1];
+      });
+      movelist[ind] = newmovenotation;
+      for (i = 0; i < ranks.length; i++) {
+        movelist[ind] += `${files[i]}${ranks[i]}`;
+      }
+      if (isDemotion) {
+        movelist[ind] += "-";
+      } else if (isPromotion) {
+        movelist[ind] += "+";
+      }
+    });
+  } catch {
+    return null;
+  }
+  return movelist.join(" ");
+}
+
+function convertUCCImovestoUCImoves(moves, board_width, board_height) {
+  const chartoindex = [
+    "z",
+    "y",
+    "x",
+    "w",
+    "v",
+    "u",
+    "t",
+    "s",
+    "r",
+    "q",
+    "p",
+    "o",
+    "n",
+    "m",
+    "l",
+    "k",
+    "j",
+    "i",
+    "h",
+    "g",
+    "f",
+    "e",
+    "d",
+    "c",
+    "b",
+    "a",
+  ];
+  if (
+    typeof moves != "string" ||
+    typeof board_width != "number" ||
+    typeof board_height != "number"
+  ) {
+    return null;
+  }
+  if (board_width < 1 || board_height < 1) {
+    return null;
+  }
+  let movelist = moves.trim().split(" ");
+  try {
+    movelist.forEach((val, ind) => {
+      if (val.length < 1) {
+        return;
+      }
+      let move = val;
+      let i = 0;
+      if (!/^([a-z][0-9]+){2}$/.test(val)) {
+        throw SyntaxError;
+      }
+      let files = move.split(/[0-9]+/).filter((str) => {
+        return str != "";
+      });
+      let ranks = move.split(/[a-z]/).filter((str) => {
+        return str != "";
+      });
+      if (ranks.length != files.length) {
+        throw SyntaxError;
+      }
+      ranks.forEach((rval, rind) => {
+        if (parseInt(rval) < 0 || parseInt(rval) > board_height - 1) {
+          throw RangeError;
+        }
+        ranks[rind] = parseInt(rval) + 1;
+      });
+      files.forEach((fval, find) => {
+        if (fval < "a" || fval > chartoindex.at(-board_width)) {
+          throw RangeError;
+        }
+      });
+      movelist[ind] = "";
+      for (i = 0; i < ranks.length; i++) {
+        movelist[ind] += `${files[i]}${ranks[i]}`;
+      }
+    });
+  } catch {
+    return null;
+  }
+  return movelist.join(" ");
+}
+
+if (window.fairyground) {
+} else {
+  throw TypeError(
+    'Namespace "fairyground" is not defined. Cannot transfer definitions to main page.',
+  );
+}
+
+window.fairyground.BinaryEngineFeature = { super: window.fairyground };
+
+window.fairyground.BinaryEngineFeature.ConvertFENtoSFEN = ConvertFENtoSFEN;
+window.fairyground.BinaryEngineFeature.convertUCCImovestoUCImoves =
+  convertUCCImovestoUCImoves;
+window.fairyground.BinaryEngineFeature.convertUCImovestoUCCImoves =
+  convertUCImovestoUCCImoves;
+window.fairyground.BinaryEngineFeature.convertUCImovestoUSImoves =
+  convertUCImovestoUSImoves;
+window.fairyground.BinaryEngineFeature.convertUSImovestoUCImoves =
+  convertUSImovestoUCImoves;
+
+window.fairyground.BinaryEngineFeature.ws = null;
+window.fairyground.BinaryEngineFeature.WebSocketStatus = "Unestablished";
+window.fairyground.BinaryEngineFeature.WebSocketReconnectionTime = 3;
+
+window.fairyground.BinaryEngineFeature.first_engine = null;
+window.fairyground.BinaryEngineFeature.second_engine = null;
+window.fairyground.BinaryEngineFeature.analysis_engine = null;
+
+//let checkconnectionnumber = parseInt(Math.random() * 100000);
+window.fairyground.BinaryEngineFeature.load_engine_timeout = 15000;
+
+//let i = 0;
+
+window.fairyground.BinaryEngineFeature.wsport = window.location.port;
+if (window.fairyground.BinaryEngineFeature.wsport == "") {
+  window.fairyground.BinaryEngineFeature.wsport = 5001;
+} else {
+  window.fairyground.BinaryEngineFeature.wsport =
+    +window.fairyground.BinaryEngineFeature.wsport + 1;
+}
+
+window.fairyground.BinaryEngineFeature.changing_engine_settings = false;
+
+const ProtocolSearchRegExp = new RegExp("(uciok)|(usiok)|(ucciok)", "i");
+const VariantOptionSearchRegExp = new RegExp(
+  "(Variant)|(UCI_Variant)|(USI_Variant)|(UCCI_Variant)",
+  "i",
+);
+const PonderOptionSearchRegExp = new RegExp(
+  "(Ponder)|(UCI_Ponder)|(USI_Ponder)|(UCCI_Ponder)",
+  "i",
+);
+const MessageSplitter = new RegExp("(?<!\\\\)\\|", "");
+const AllBlankTestRegExp = new RegExp("^[ ]*$", "");
+
+function GetCurrentVariantID() {
+  return document.getElementById("dropdown-variant").value;
+}
+
+window.fairyground.BinaryEngineFeature.GetCurrentVariantID =
+  GetCurrentVariantID;
+
+function MakeMoveOnBoard(ucimove) {
+  if (typeof ucimove != "string") {
+    throw TypeError();
+  }
+  const moves = document.getElementById("move");
+  const applypos = document.getElementById("set");
+  moves.value = moves.value.trim() + " " + ucimove;
+  applypos.click();
+}
+
+window.fairyground.BinaryEngineFeature.MakeMoveOnBoard = MakeMoveOnBoard;
+
+function GetBoardWidth() {
+  const ClassList = document.getElementById(
+    "chessground-container-div",
+  ).classList;
+  let boardsize = "";
+  try {
+    ClassList.forEach((val) => {
+      if (/board[0-9]+x[0-9]+/.test(val)) {
+        throw val;
+      }
+    });
+  } catch (e) {
+    boardsize = e;
+  }
+  return parseInt(boardsize.replace("board", "").split("x")[0]);
+}
+
+window.fairyground.BinaryEngineFeature.GetBoardWidth = GetBoardWidth;
+
+function GetBoardHeight() {
+  const ClassList = document.getElementById(
+    "chessground-container-div",
+  ).classList;
+  let boardsize = "";
+  try {
+    ClassList.forEach((val) => {
+      if (/board[0-9]+x[0-9]+/.test(val)) {
+        throw val;
+      }
+    });
+  } catch (e) {
+    boardsize = e;
+  }
+  return parseInt(boardsize.replace("board", "").split("x")[1]);
+}
+
+window.fairyground.BinaryEngineFeature.GetBoardHeight = GetBoardHeight;
+
+function GetBoardPosition() {
+  const fen = document.getElementById("fen").value.trim();
+  const moves = document.getElementById("move").value.trim();
+  return { fen: fen, moves: moves };
+}
+
+window.fairyground.BinaryEngineFeature.GetBoardPosition = GetBoardPosition;
+
+function UpdateOutputSection(color, msg) {
+  if (typeof color != "string" || typeof msg != "string") {
+    throw TypeError();
+  }
+  switch (color) {
+    case "WHITE": {
+      const output = document.getElementById("whiteengineoutput");
+      output.innerText += msg + "\n";
+      break;
+    }
+    case "BLACK": {
+      const output = document.getElementById("blackengineoutput");
+      output.innerText += msg + "\n";
+      break;
+    }
+    case "ANALYSIS": {
+      const output = document.getElementById("analysisengineoutput");
+      output.innerText += msg + "\n";
+      break;
+    }
+  }
+}
+
+window.fairyground.BinaryEngineFeature.UpdateOutputSection =
+  UpdateOutputSection;
+
+function GetCurrentPlayingEngine() {
+  const playwhite = document.getElementById("playwhite");
+  const playblack = document.getElementById("playblack");
+  const isanalysis = document.getElementById("analysis");
+  const stm = document.getElementById("label-stm");
+  if (
+    isanalysis.checked &&
+    window.fairyground.BinaryEngineFeature.analysis_engine != null
+  ) {
+    return "ANALYSIS";
+  }
+  if (
+    playwhite.checked &&
+    stm.innerText == "white" &&
+    window.fairyground.BinaryEngineFeature.first_engine != null
+  ) {
+    return "WHITE";
+  }
+  if (
+    playblack.checked &&
+    stm.innerText == "black" &&
+    window.fairyground.BinaryEngineFeature.second_engine != null
+  ) {
+    return "BLACK";
+  }
+  return "DEFAULT";
+}
+
+window.fairyground.BinaryEngineFeature.GetCurrentPlayingEngine =
+  GetCurrentPlayingEngine;
+
+function EnginePlaysColor(color) {
+  if (typeof color != "string") {
+    throw TypeError();
+  }
+  const playwhite = document.getElementById("playwhite");
+  const playblack = document.getElementById("playblack");
+  const isanalysis = document.getElementById("analysis");
+  const stm = document.getElementById("label-stm");
+  switch (color) {
+    case "WHITE": {
+      return (
+        playwhite.checked &&
+        stm.innerText == "white" &&
+        window.fairyground.BinaryEngineFeature.first_engine != null
+      );
+    }
+    case "BLACK": {
+      return (
+        playblack.checked &&
+        stm.innerText == "black" &&
+        window.fairyground.BinaryEngineFeature.second_engine != null
+      );
+    }
+    case "ANALYSIS": {
+      return (
+        isanalysis.checked &&
+        window.fairyground.BinaryEngineFeature.analysis_engine != null
+      );
+    }
+    case "DEFAULT": {
+      return (
+        (playwhite.checked &&
+          stm.innerText == "white" &&
+          window.fairyground.BinaryEngineFeature.first_engine == null) ||
+        (playblack.checked &&
+          stm.innerText == "black" &&
+          window.fairyground.BinaryEngineFeature.second_engine == null) ||
+        (isanalysis.checked &&
+          window.fairyground.BinaryEngineFeature.analysis_engine == null)
+      );
+    }
+    default: {
+      return false;
+    }
+  }
+}
+
+window.fairyground.BinaryEngineFeature.EnginePlaysColor = EnginePlaysColor;
+
+function IsNullMove(ucimove) {
+  if (typeof ucimove != "string") {
+    throw TypeError();
+  }
+  return (
+    ucimove == "0000" ||
+    ucimove == "(none)" ||
+    ucimove == "none" ||
+    ucimove == "null"
+  );
+}
+
+window.fairyground.BinaryEngineFeature.IsNullMove = IsNullMove;
+
+function GetEngineID(color) {
+  if (typeof color != "string") {
+    throw TypeError();
+  }
+  switch (color) {
+    case "WHITE": {
+      return document.getElementById("whiteengineid").innerText;
+    }
+    case "BLACK": {
+      return document.getElementById("blackengineid").innerText;
+    }
+    case "ANALYSIS": {
+      return document.getElementById("analysisengineid").innerText;
+    }
+  }
+  return "";
+}
+
+window.fairyground.BinaryEngineFeature.GetEngineID = GetEngineID;
+
+function ParseSavedEngineListMessage(msg) {
+  if (typeof msg != "string") {
+    throw TypeError();
+  }
+  let list = [];
+  let entries = msg.split("/");
+  entries.forEach((val) => {
+    let enginesettings = val.split(";");
+    if (enginesettings.length != 5) {
+      return;
+    }
+    let engineid = enginesettings[0];
+    let enginepath = enginesettings[1];
+    let enginewd = enginesettings[2];
+    let engineprotocol = enginesettings[3];
+    let engineoptionstxt = enginesettings[4].split(",");
+    let options = [];
+    engineoptionstxt.forEach((val2) => {
+      let pair = val2.split("=");
+      if (pair.length != 2) {
+        return;
+      }
+      options.push({ name: pair[0], current: pair[1] });
+    });
+    list.push({
+      id: engineid,
+      path: enginepath,
+      working_directory: enginewd,
+      protocol: engineprotocol,
+      options: options,
+    });
+  });
+  return list;
+}
+
+window.fairyground.BinaryEngineFeature.ParseSavedEngineListMessage =
+  ParseSavedEngineListMessage;
+
+function ConvertEngineListToText(list) {
+  if (!Array.isArray(list)) {
+    throw TypeError();
+  }
+  let strlist = [];
+  list.forEach((item) => {
+    let id = item.id;
+    let path = item.path;
+    let protocol = item.protocol;
+    let wd = item.working_directory;
+    let options = item.options;
+    let optionlist = [];
+    options.forEach((item2) => {
+      optionlist.push(`${item2.name}=${item2.current}`);
+    });
+    let optiontxt = optionlist.join(",");
+    strlist.push(`${id};${path};${wd};${protocol};${optiontxt}`);
+  });
+  return strlist.join("/");
+}
+
+window.fairyground.BinaryEngineFeature.ConvertEngineListToText =
+  ConvertEngineListToText;
+
+function GetEngineList(GetFinishCallBack, ws) {
+  if (
+    !WebSocket.prototype.isPrototypeOf(ws) ||
+    typeof GetFinishCallBack != "function"
+  ) {
+    throw TypeError();
+  }
+  if (ws.readyState != ws.OPEN) {
+    throw Error("WebSocket connetion error");
+  }
+  function OnGetEngineListMessageReceived(event) {
+    let msg = event.data.split("|");
+    if (msg[0] == "ENGINE_LIST") {
+      let list = ParseSavedEngineListMessage(msg[1]);
+      ws.removeEventListener("message", OnGetEngineListMessageReceived);
+      GetFinishCallBack(list);
+    }
+  }
+  ws.addEventListener("message", OnGetEngineListMessageReceived);
+  ws.send("GET_ENGINE_LIST");
+}
+
+window.fairyground.BinaryEngineFeature.GetEngineList = GetEngineList;
+
+function SaveEngineList(EngineList, ws) {
+  if (!Array.isArray(EngineList) || !WebSocket.prototype.isPrototypeOf(ws)) {
+    throw TypeError();
+  }
+  if (ws.readyState != ws.OPEN) {
+    throw Error("WebSocket connetion error");
+  }
+  let text = ConvertEngineListToText(EngineList);
+  ws.send(`SAVE_ENGINE_LIST|${text}`);
+}
+
+window.fairyground.BinaryEngineFeature.SaveEngineList = SaveEngineList;
+
+function GetEngineItem(list, id) {
+  if (!Array.isArray(list) || typeof id != "string") {
+    throw TypeError();
+  }
+  try {
+    list.forEach((item) => {
+      if (item.id == id) {
+        throw item;
+      }
+    });
+  } catch (e) {
+    return e;
+  }
+  return null;
+}
+
+window.fairyground.BinaryEngineFeature.GetEngineItem = GetEngineItem;
+
+function SetEngineItem(list, id, path, workdirectory, protocol, options) {
+  if (
+    !Array.isArray(list) ||
+    typeof id != "string" ||
+    typeof path != "string" ||
+    typeof workdirectory != "string" ||
+    typeof protocol != "string" ||
+    !Array.isArray(options)
+  ) {
+    throw TypeError();
+  }
+  list.forEach((item, ind) => {
+    if (item.id == id) {
+      list[ind] = {
+        id: id,
+        path: path,
+        working_directory: workdirectory,
+        protocol: protocol,
+        options: options,
+      };
+    }
+  });
+}
+
+window.fairyground.BinaryEngineFeature.SetEngineItem = SetEngineItem;
+
+function AddEngineItem(list, id, path, workdirectory, protocol, options) {
+  if (
+    !Array.isArray(list) ||
+    typeof id != "string" ||
+    typeof path != "string" ||
+    typeof workdirectory != "string" ||
+    typeof protocol != "string" ||
+    !Array.isArray(options)
+  ) {
+    throw TypeError();
+  }
+  try {
+    list.forEach((item, ind) => {
+      if (item.id == id) {
+        throw ind;
+      }
+    });
+  } catch (e) {
+    console.error("Given ID already exists in the list.");
+    throw e;
+  }
+  list.push({
+    id: id,
+    path: path,
+    working_directory: workdirectory,
+    protocol: protocol,
+    options: options,
+  });
+}
+
+window.fairyground.BinaryEngineFeature.AddEngineItem = AddEngineItem;
+
+function RemoveEngineItem(list, id) {
+  if (!Array.isArray(list) || typeof id != "string") {
+    throw TypeError();
+  }
+  try {
+    list.forEach((item, ind) => {
+      if (item.id == id) {
+        list.splice(ind, 1);
+        throw item;
+      }
+    });
+  } catch (e) {
+    return e;
+  }
+  return null;
+}
+
+window.fairyground.BinaryEngineFeature.RemoveEngineItem = RemoveEngineItem;
+
+function IsNullValue(val) {
+  if (val !== null && val !== undefined && val != "") {
+    if (val != "null" && val != "undefined") {
+      if (typeof val == "number" && isNaN(val)) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+window.fairyground.BinaryEngineFeature.IsNullValue = IsNullValue;
+
+function DownloadFile(content, fileName, mimeType) {
+  const blob = new Blob([content], { type: mimeType });
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+window.fairyground.BinaryEngineFeature.DownloadFile = DownloadFile;
+
+//let wsa=new WebSocket("ws");
+
+class Engine {
+  constructor(
+    ID,
+    Command,
+    WorkingDirectory,
+    Protocol,
+    Options,
+    Color,
+    LoadTimeOut,
+    WebSocketConnection,
+  ) {
+    if (
+      typeof ID != "string" ||
+      typeof Command != "string" ||
+      typeof WorkingDirectory != "string" ||
+      typeof Protocol != "string" ||
+      !Array.isArray(Options) ||
+      typeof Color != "string" ||
+      typeof LoadTimeOut != "number" ||
+      !WebSocket.prototype.isPrototypeOf(WebSocketConnection)
+    ) {
+      throw TypeError();
+    }
+    if (WebSocketConnection.readyState != WebSocketConnection.OPEN) {
+      throw Error("WebSocket connection error");
+    }
+    this.ID = ID.replace("|", "\\|");
+    this.Name = "";
+    this.Author = "";
+    this.Command = Command.replace("|", "\\|");
+    this.WorkingDirectory = WorkingDirectory.replace("|", "\\|");
+    this.Protocol = Protocol.replace("|", "\\|");
+    this.Options = Options;
+    this.Color = Color.replace("|", "\\|");
+    this.IsUsing = false;
+    this.IsLoading = false;
+    this.IsLoaded = false;
+    this.Variants = [];
+    this.HasVariantsOption = false;
+    this.WebSocketConnection = WebSocketConnection;
+    this.Move = "";
+    this.Ponder = false;
+    this.PonderMove = "0000";
+    this.PonderMiss = false;
+    this.IsStochasticPonder = false;
+    this.ShowEvalutionInformation = false;
+    this.DataStream = "";
+    this.MessageBuffer = [];
+    this.IsAnalysisEngine = false;
+    this.SupportsByoyomi = false;
+    this.MateEvaluationFactor = 2147483647;
+    this.MaxMultiplePrincipalVariationCount = 4096;
+    this.RecordedMultiplePrincipalVariation = 0;
+    this.MultiplePrincipalVariationRecord = [];
+    this.EvaluationIndex = [];
+    this.LoadTimeOut = LoadTimeOut;
+    this.LoadFinishCallBack = undefined;
+    this.LoadFailureCallBack = undefined;
+    this.IsReadyCallBack = undefined;
+    this.SetIDCallBack = undefined;
+    this.EvaluationUpdateCallBack = undefined;
+    this.OutputUpdateCallBack = undefined;
+    if (Color == "ANALYSIS") {
+      this.IsAnalysisEngine = true;
+    }
+    this.WebSocketOnMessageHandlerBinded =
+      this.WebSocketOnMessageHandler.bind(this);
+    this.WebSocketOnSocketInvalidHandlerBinded =
+      this.WebSocketOnSocketInvalidHandler.bind(this);
+    this.WebSocketConnection.addEventListener(
+      "close",
+      this.WebSocketOnSocketInvalidHandlerBinded,
+    );
+    this.WebSocketConnection.addEventListener(
+      "message",
+      this.WebSocketOnMessageHandlerBinded,
+    );
+    this.WebSocketConnection.addEventListener(
+      "error",
+      this.WebSocketOnSocketInvalidHandlerBinded,
+    );
+    for (let i = 0; i < this.MaxMultiplePrincipalVariationCount; i++) {
+      this.MultiplePrincipalVariationRecord.push([
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+      ]);
+      this.EvaluationIndex.push(0);
+    }
+  }
+
+  destructor() {
+    this.WebSocketConnection.removeEventListener(
+      "close",
+      this.WebSocketOnSocketInvalidHandlerBinded,
+    );
+    this.WebSocketConnection.removeEventListener(
+      "message",
+      this.WebSocketOnMessageHandlerBinded,
+    );
+    this.WebSocketConnection.removeEventListener(
+      "error",
+      this.WebSocketOnSocketInvalidHandlerBinded,
+    );
+    if (this.WebSocketConnection.readyState == this.WebSocketConnection.OPEN) {
+      this.WebSocketConnection.send(`EXIT_ENGINE|${this.ID}|${this.Color}`);
+    }
+    this.IsUsing = false;
+    this.IsLoaded = false;
+    this.IsLoading = false;
+    delete this;
+  }
+
+  Load(LoadFinishCallBack, LoadFailureCallBack) {
+    if (
+      typeof LoadFinishCallBack != "function" &&
+      LoadFinishCallBack !== undefined
+    ) {
+      throw TypeError();
+    }
+    if (
+      typeof LoadFailureCallBack != "function" &&
+      LoadFailureCallBack !== undefined
+    ) {
+      throw TypeError();
+    }
+    if (this.WebSocketConnection.readyState != this.WebSocketConnection.OPEN) {
+      return false;
+    }
+    this.IsLoading = true;
+    this.IsLoaded = false;
+    this.DataStream = "";
+    this.Variants = [];
+    this.Ponder = false;
+    this.PonderMiss = false;
+    this.PonderMove = "0000";
+    this.Move = "0000";
+    this.LoadFinishCallBack = LoadFinishCallBack;
+    this.LoadFailureCallBack = LoadFailureCallBack;
+    this.WebSocketConnection.send(
+      `LOAD_ENGINE|${this.ID}|${this.Color}|${this.Protocol}|${this.Command}|${this.WorkingDirectory}|${this.LoadTimeOut}`,
+    );
+    return true;
+  }
+
+  OnReceivedMessageFromServer(Message) {
+    if (typeof Message != "string") {
+      throw TypeError();
+    }
+    //console.log(Message);
+    //console.log(this.Color, this.ID);
+    let msg = Message.split(MessageSplitter);
+    //console.log(msg);
+    if (
+      msg[0] == "ENGINE_STDOUT" &&
+      msg[1] == this.ID &&
+      msg[2] == this.Color
+    ) {
+      this.DataStream += msg[3].replace(/(\r\n)|(\r)/g, "\n");
+      let index = this.DataStream.indexOf("\n");
+      if (index >= 0) {
+        do {
+          this.ParseEngineOutput(this.DataStream.slice(0, index));
+          this.DataStream = this.DataStream.slice(index + 1);
+          index = this.DataStream.indexOf("\n");
+        } while (index >= 0);
+      }
+    } else if (msg[0] == "ERROR") {
+      if (
+        msg[1] == "LOAD_ENGINE" &&
+        msg[2] == this.ID &&
+        msg[3] == this.Color
+      ) {
+        this.IsLoading = false;
+        this.IsLoaded = false;
+        this.IsUsing = false;
+        if (typeof this.LoadFailureCallBack == "function") {
+          console.error("Engine exited unexpectedly.");
+          this.LoadFailureCallBack("Engine exited unexpectedly.");
+        }
+      } else if (
+        msg[1] == "ENGINE_TIMEOUT" &&
+        msg[2] == this.ID &&
+        msg[3] == this.Color
+      ) {
+        this.IsLoading = false;
+        this.IsLoaded = false;
+        this.IsUsing = false;
+        if (typeof this.LoadFailureCallBack == "function") {
+          console.error("Engine load timed out.");
+          this.LoadFailureCallBack("Engine load timed out.");
+        }
+      }
+    } else if (
+      msg[0] == "ENGINE_STDERR" &&
+      msg[1] == this.ID &&
+      msg[2] == this.Color
+    ) {
+      if (AllBlankTestRegExp.test(msg[3])) {
+        return;
+      }
+      console.error("Engine " + msg[2] + " Error: " + msg[3]);
+    } else if (
+      msg[0] == "ID_CHANGED" &&
+      msg[1] == this.ID &&
+      msg[2] == this.Color
+    ) {
+      if (typeof this.SetIDCallBack == "function") {
+        this.SetIDCallBack(this.ID);
+      }
+    }
+  }
+
+  ParseEngineOutput(Message) {
+    if (typeof Message != "string") {
+      throw TypeError();
+    }
+    if (this.IsLoaded) {
+      if (typeof this.OutputUpdateCallBack == "function") {
+        this.OutputUpdateCallBack(this.Color, Message);
+      }
+      if (Message.startsWith("bestmove")) {
+        //console.log(`${this.Color} Receive: ${Message}`);
+        if (EnginePlaysColor(this.Color)) {
+          if (this.Ponder && this.PonderMiss) {
+            this.PonderMiss = false;
+          } else {
+            let bestmoveline = Message.split(" ");
+            if (bestmoveline[1] == "resign" || bestmoveline[2] == "resign") {
+              if (this.IsAnalysisEngine) {
+                window.alert(
+                  `${this.Name} (${this.Color}) suggests current mover to resign.`,
+                );
+              } else {
+                window.alert(`${this.Name} (${this.Color}) has resigned.`);
+              }
+            } else if (bestmoveline[1] == "win" || bestmoveline[1] == "lose") {
+            } else {
+              if (IsNullMove(bestmoveline[1])) {
+                this.Move = "0000";
+              } else {
+                this.SetMoveInUCIFormat(bestmoveline[1]);
+                if (!this.IsAnalysisEngine && !this.PonderMiss) {
+                  this.CommitMove();
+                }
+              }
+            }
+            if (bestmoveline[2] == "draw") {
+              this.SetPonderMoveInUCIFormat(bestmoveline[4]);
+            } else {
+              this.SetPonderMoveInUCIFormat(bestmoveline[3]);
+            }
+            if (this.PonderMove == undefined) {
+              this.PonderMove = "0000";
+            }
+            console.log(
+              `${this.Color}: Move: ${this.Move} Ponder: ${this.PonderMove}`,
+            );
+          }
+        }
+      } else if (Message.includes("readyok")) {
+        if (typeof this.IsReadyCallBack == "function") {
+          this.IsReadyCallBack();
+        }
+      } else if (typeof this.EvaluationUpdateCallBack == "function") {
+        if (/( upperbound )|( lowerbound )/.test(Message)) {
+          return;
+        }
+        /*let multipvid = 0;
+                let bestpv = 0;
+                if (Message.includes(" multipv ")) {
+                    let textparselist = Message.split(" ");
+                    multipvid = parseInt(textparselist[textparselist.indexOf("multipv") + 1]) - 1;
+                    if (multipvid + 1 > this.RecordedMultiplePrincipalVariation) {
+                        this.RecordedMultiplePrincipalVariation = multipvid + 1;
+                    }
+                }
+                let bestmove = [];
+                let ponder = [];
+                if (Message.includes(" score ") && Message.includes(" pv ")) {
+                    let textparselist = Message.split(" ");
+                    let evaltext = textparselist.at(textparselist.indexOf("score") + 1);
+                    if (evaltext == "mate") {
+                        let matenum = parseInt(
+                            textparselist.at(textparselist.indexOf("score") + 2),
+                        );
+                        this.MultiplePrincipalVariationRecord[multipvid][0] = true;
+                        this.MultiplePrincipalVariationRecord[multipvid][1] = matenum;
+                        this.EvaluationIndex[multipvid] = mateevalfactor / matenum;
+                        evaluation = this.EvaluationIndex[multipvid];
+                    } else if (evaltext == "cp") {
+                        let evalval =
+                            parseInt(textparselist.at(textparselist.indexOf("score") + 2)) / 100;
+                        this.MultiplePrincipalVariationRecord[multipvid][0] = false;
+                        this.MultiplePrincipalVariationRecord[multipvid][1] = evalval;
+                        this.EvaluationIndex[multipvid] = evalval;
+                        evaluation = this.EvaluationIndex[multipvid];
+                    } else {
+                        this.MultiplePrincipalVariationRecord[multipvid][0] = false;
+                        this.MultiplePrincipalVariationRecord[multipvid][1] = 0;
+                        this.EvaluationIndex[multipvid] = 0;
+                        console.log("Detected bad evaluation");
+                    }
+                    let moves = textparselist.slice(textparselist.indexOf("pv") + 1);
+                    if (moves.length == 0) {
+                        return;
+                    } else if (moves.length == 1) {
+                        bestmove = this.ParseMove(moves[0]);
+                    } else {
+                        bestmove = this.ParseMove(moves[0]);
+                        ponder = this.ParseMove(moves[1]);
+                    }
+                    this.MultiplePrincipalVariationRecord[multipvid][2] = bestmove;
+                    this.MultiplePrincipalVariationRecord[multipvid][3] = ponder;
+                    if (this.Protocol == "USI") {
+                        this.MultiplePrincipalVariationRecord[multipvid][4] = convertUSImovestoUCImoves(textparselist.slice(textparselist.indexOf("pv") + 1).join(" "), GetBoardWidth(), GetBoardHeight());
+                    }
+                    else if (this.Protocol == "UCCI" || this.Protocol == "UCI_CYCLONE") {
+                        this.MultiplePrincipalVariationRecord[multipvid][4] = convertUCCImovestoUCImoves(textparselist.slice(textparselist.indexOf("pv") + 1).join(" "), GetBoardWidth(), GetBoardHeight());
+                    }
+                    else {
+                        this.MultiplePrincipalVariationRecord[multipvid][4] = textparselist.slice(textparselist.indexOf("pv") + 1).join(" ");
+                    }
+                    this.MultiplePrincipalVariationRecord[multipvid][5] = parseInt(
+                        textparselist[textparselist.indexOf("depth") + 1],
+                    );
+                    this.MultiplePrincipalVariationRecord[multipvid][6] = parseInt(
+                        textparselist[textparselist.indexOf("seldepth") + 1],
+                    );
+                    this.EvaluationUpdateCallBack(this.RecordedMultiplePrincipalVariation, this.MultiplePrincipalVariationRecord, this.EvaluationIndex, parseInt(textparselist[textparselist.indexOf("nodes") + 1]), parseInt(textparselist[textparselist.indexOf("nps") + 1]));
+                }
+                else if (Message.includes("bestmove")) {
+                    let textparselist = Message.split(" ");
+                    bestpv = this.EvaluationIndex.indexOf(
+                        Math.max(...this.EvaluationIndex.slice(0, this.RecordedMultiplePrincipalVariation)),
+                    );
+                    bestmove = this.ParseMove(textparselist[1]);
+                    if (textparselist[3] != undefined) {
+                        ponder = this.ParseMove(textparselist[3]);
+                    }
+                    this.MultiplePrincipalVariationRecord[bestpv][2] = bestmove;
+                    this.MultiplePrincipalVariationRecord[bestpv][3] = ponder;
+                    this.EvaluationUpdateCallBack(this.RecordedMultiplePrincipalVariation, this.MultiplePrincipalVariationRecord, this.EvaluationIndex, NaN, NaN);
+                }*/
+        if (Message.includes(" score ") && Message.includes(" pv ")) {
+          let msglist = Message.split(" ");
+          let pv = msglist.slice(msglist.indexOf("pv") + 1);
+          msglist = msglist.slice(0, msglist.indexOf("pv"));
+          let moves = pv.join(" ");
+          if (this.Protocol == "USI") {
+            moves = convertUSImovestoUCImoves(
+              moves,
+              GetBoardWidth(),
+              GetBoardHeight(),
+            );
+          } else if (
+            this.Protocol == "UCCI" ||
+            this.Protocol == "UCI_CYCLONE"
+          ) {
+            moves = convertUCCImovestoUCImoves(
+              moves,
+              GetBoardWidth(),
+              GetBoardHeight(),
+            );
+          }
+          this.EvaluationUpdateCallBack(msglist.join(" ") + " pv " + moves);
+        }
+      }
+    } else if (this.IsLoading) {
+      this.MessageBuffer.push(Message);
+      if (ProtocolSearchRegExp.test(Message)) {
+        this.ParseEngineInitializationOutput(this.MessageBuffer);
+        this.SetOptions(this.Options);
+        this.MessageBuffer = [];
+      } else if (Message.includes("readyok")) {
+        this.WebSocketConnection.send(`ENGINE_READY|${this.ID}|${this.Color}`);
+        this.IsLoaded = true;
+        this.IsLoading = false;
+        if (this.Variants.includes(GetCurrentVariantID())) {
+          this.IsUsing = true;
+          if (this.HasVariantsOption) {
+            this.SetVariant(GetCurrentVariantID());
+          }
+          this.NewGame();
+          let position = GetBoardPosition();
+          this.SetPosition(
+            position.fen,
+            position.moves,
+            GetBoardWidth(),
+            GetBoardHeight(),
+          );
+        } else {
+          console.log(
+            "Engine " +
+              this.Color +
+              ": " +
+              this.Name +
+              ' does not support variant "' +
+              GetCurrentVariantID() +
+              '". In browser Fairy-Stockfish will be used instead.',
+          );
+          this.IsUsing = false;
+        }
+        let info = `Engine ${this.Color}:\nName: ${this.Name}\nAuthor: ${this.Author}\n`;
+        if (this.Protocol == "UCI") {
+          info += "uciok\n";
+        } else if (this.Protocol == "USI") {
+          info += "usiok\n";
+        } else if (this.Protocol == "UCCI") {
+          info += "ucciok\n";
+        } else if (this.Protocol == "UCI_CYCLONE") {
+          info += "uciok (cyclone)\n";
+        } else {
+          throw TypeError(`Unknown protocol: ${this.Protocol}`);
+        }
+        if (typeof this.OutputUpdateCallBack == "function") {
+          this.OutputUpdateCallBack(this.Color, info);
+        }
+        this.MessageBuffer = [];
+        if (typeof this.LoadFinishCallBack == "function") {
+          this.LoadFinishCallBack(this.Name, this.Author);
+        }
+      }
+    }
+  }
+
+  ParseMove(MoveNotation) {
+    if (typeof MoveNotation != "string") {
+      throw TypeError;
+    }
+    let move = "";
+    if (this.Protocol == "USI") {
+      move = convertUSImovestoUCImoves(
+        MoveNotation,
+        GetBoardWidth(),
+        GetBoardHeight(),
+      );
+    } else if (this.Protocol == "UCCI" || this.Protocol == "UCI_CYCLONE") {
+      move = convertUCCImovestoUCImoves(
+        MoveNotation,
+        GetBoardWidth(),
+        GetBoardHeight(),
+      );
+    } else {
+      move = MoveNotation;
+    }
+    let gatingmove = "";
+    if (move.includes(",")) {
+      let gating = move.split(",")[1];
+      move = move.split(",")[0];
+      gatingmove =
+        gating.split(/[0-9]+/).filter(function (item) {
+          return item != null && item != undefined && item != "";
+        })[1] +
+        gating.split(/[a-z]+/).filter(function (item) {
+          return item != null && item != undefined && item != "";
+        })[1];
+    }
+    if (move.includes("@")) {
+      return [
+        move.slice(0, move.indexOf("@") + 1),
+        move.slice(move.indexOf("@") + 1),
+        "",
+        gatingmove,
+      ];
+    }
+    let additional = "";
+    if (move.at(-1) == "+") {
+      additional = "+";
+      move = move.slice(0, -1);
+    } else if (move.at(-1) == "-") {
+      additional = "-";
+      move = move.slice(0, -1);
+    } else if (/^[a-z]{1}$/.test(move.at(-1))) {
+      additional = move.at(-1);
+      move = move.slice(0, -1);
+    }
+    let files = move.split(/[0-9]+/).filter(function (item) {
+      return item != null && item != undefined && item != "";
+    });
+    let ranks = move.split(/[a-z]+/).filter(function (item) {
+      return item != null && item != undefined && item != "";
+    });
+    if (files.length != 2) {
+      throw RangeError;
+    }
+    if (ranks.length != 2) {
+      throw RangeError;
+    }
+    return [files[0] + ranks[0], files[1] + ranks[1], additional, gatingmove];
+  }
+
+  ParseEngineInitializationOutput(MessageBuffer) {
+    if (!Array.isArray(MessageBuffer)) {
+      throw TypeError();
+    }
+    let engine_info = MessageBuffer;
+    let optionlist = [];
+    let i = 0;
+    let engine_name = "";
+    let engine_author = "";
+    let ponder = false;
+    let variants = [];
+    let variants_option = false;
+    for (i = 0; i < engine_info.length; i++) {
+      if (engine_info[i].startsWith("id name")) {
+        engine_name = engine_info[i].split(" ").slice(2).join(" ");
+      } else if (engine_info[i].startsWith("id author")) {
+        engine_author = engine_info[i].split(" ").slice(2).join(" ");
+      } else if (engine_info[i].startsWith("option ")) {
+        let options = engine_info[i].split(" ");
+        let optionname = options.slice(2, options.indexOf("type")).join(" ");
+        if (this.Protocol == "UCCI") {
+          optionname = options.slice(1, options.indexOf("type")).join(" ");
+        }
+        let optiontype = options[options.indexOf("type") + 1];
+        if (optiontype == "button") {
+          optionlist.push({
+            name: optionname,
+            type: optiontype,
+            default: null,
+            min: null,
+            max: null,
+            values: null,
+            current: null,
+          });
+          continue;
+        }
+        let optiondefault = options[options.indexOf("default") + 1];
+        if (optiontype == "check" || optiontype == "string") {
+          optionlist.push({
+            name: optionname,
+            type: optiontype,
+            default: optiondefault,
+            min: null,
+            max: null,
+            values: null,
+            current: null,
+          });
+          if (PonderOptionSearchRegExp.test(optionname)) {
+            if (optiondefault == "true") {
+              ponder = true;
+            } else {
+              ponder = false;
+            }
+          }
+        } else if (optiontype == "spin") {
+          optionlist.push({
+            name: optionname,
+            type: optiontype,
+            default: optiondefault,
+            min: options[options.indexOf("min") + 1],
+            max: options[options.indexOf("max") + 1],
+            values: null,
+            current: null,
+          });
+        } else if (optiontype == "combo") {
+          let dropdownoptions = options
+            .slice(options.indexOf("default") + 1)
+            .join(" ")
+            .split(" var ")
+            .slice(1);
+          optionlist.push({
+            name: optionname,
+            type: optiontype,
+            default: optiondefault,
+            min: null,
+            max: null,
+            values: dropdownoptions,
+            current: null,
+          });
+          if (VariantOptionSearchRegExp.test(optionname)) {
+            variants = dropdownoptions.slice(0);
+            variants_option = true;
+          }
+        } else {
+          console.warn(
+            "Unknown option type:" +
+              optiontype +
+              ".\nThis option will be ignored.",
+          );
+        }
+      } else if (ProtocolSearchRegExp.test(engine_info[i])) {
+        console.log("Engine loaded.");
+        console.log(`Name: ${engine_name}\nAuthor: ${engine_author}`);
+        //console.log(optionlist);
+        if (variants.length == 0) {
+          if (this.Protocol == "UCI") {
+            variants = ["chess", "fischerandom", ""];
+          } else if (this.Protocol == "USI") {
+            variants = ["shogi"];
+          } else if (
+            this.Protocol == "UCCI" ||
+            this.Protocol == "UCI_CYCLONE"
+          ) {
+            variants = ["xiangqi"];
+          }
+          variants_option = false;
+        }
+        break;
+      }
+    }
+    this.Name = engine_name;
+    this.Author = engine_author;
+    this.Ponder = ponder;
+    this.Variants = variants;
+    if (this.Options.length > 0) {
+      this.Options.forEach((val, ind) => {
+        optionlist.forEach((val2, ind2) => {
+          if (val.name == val2.name) {
+            if (IsNullValue(val.current)) {
+              optionlist[ind2].current = val.default;
+            } else {
+              optionlist[ind2].current = val.current;
+            }
+            if (IsNullValue(val2.current)) {
+              optionlist[ind2].current = val2.default;
+            }
+          }
+        });
+      });
+    }
+    this.Options = optionlist;
+    this.HasVariantsOption = variants_option;
+  }
+
+  PostMessage(Message) {
+    if (typeof Message != "string") {
+      throw TypeError();
+    }
+    //console.log(`Send ${this.Color}: ${Message}`);
+    //console.log(Error());
+    this.WebSocketConnection.send(
+      `POST_MSG|${this.ID}|${this.Color}|${Message}`,
+    );
+  }
+
+  SetOption(OptionName, OptionValue) {
+    if (typeof OptionName != "string" || typeof OptionValue != "string") {
+      throw TypeError();
+    }
+    if (
+      this.Protocol == "UCI" ||
+      this.Protocol == "USI" ||
+      this.Protocol == "UCI_CYCLONE"
+    ) {
+      this.PostMessage(`setoption name ${OptionName} value ${OptionValue}`);
+    } else if (this.Protocol == "UCCI") {
+      this.PostMessage(`setoption ${OptionName} ${OptionValue}`);
+    }
+    if (
+      OptionName == "Ponder" ||
+      OptionName == "UCI_Ponder" ||
+      OptionName == "USI_Ponder" ||
+      OptionName == "UCCI_Ponder"
+    ) {
+      if (OptionValue == "true") {
+        this.Ponder = true;
+      } else {
+        this.Ponder = false;
+      }
+    }
+  }
+
+  SetButtonOption(OptionName) {
+    if (typeof OptionName != "string") {
+      throw TypeError();
+    }
+    if (
+      this.Protocol == "UCI" ||
+      this.Protocol == "USI" ||
+      this.Protocol == "UCI_CYCLONE"
+    ) {
+      this.PostMessage(`setoption name ${OptionName}`);
+    } else if (this.Protocol == "UCCI") {
+      this.PostMessage(`setoption ${OptionName}`);
+    }
+  }
+
+  SetOptions(OptionList) {
+    if (!Array.isArray(OptionList)) {
+      throw TypeError();
+    }
+    OptionList.forEach((val) => {
+      if (IsNullValue(val.current)) {
+        return;
+      }
+      if (/protocol|variant/i.test(val.name)) {
+        return;
+      }
+      this.SetOption(val.name, val.current);
+    });
+    this.PostMessage(`isready`);
+  }
+
+  SaveOptionsToEngineList(EngineList) {
+    if (!Array.isArray(EngineList)) {
+      throw TypeError();
+    }
+    let item = GetEngineItem(EngineList, this.ID);
+    if (item) {
+      SetEngineItem(
+        EngineList,
+        this.ID,
+        this.Command,
+        this.WorkingDirectory,
+        this.Protocol,
+        this.Options,
+      );
+    } else {
+      AddEngineItem(
+        EngineList,
+        this.ID,
+        this.Command,
+        this.WorkingDirectory,
+        this.Protocol,
+        this.Options,
+      );
+    }
+  }
+
+  NewGame() {
+    this.PostMessage("stop");
+    this.RecordedMultiplePrincipalVariation = 0;
+    if (this.Protocol == "UCI" || this.Protocol == "UCI_CYCLONE") {
+      this.PostMessage("ucinewgame");
+    } else if (this.Protocol == "USI") {
+      this.PostMessage("usinewgame");
+    } else if (this.Protocol == "UCCI") {
+      this.PostMessage("uccinewgame");
+    }
+  }
+
+  SetPosition(FEN, Moves, BoardWidth, BoardHeight) {
+    if (
+      typeof FEN != "string" ||
+      typeof Moves != "string" ||
+      typeof BoardWidth != "number" ||
+      typeof BoardHeight != "number"
+    ) {
+      throw TypeError();
+    }
+    if (!this.IsUsing) {
+      return;
+    }
+    this.RecordedMultiplePrincipalVariation = 0;
+    if (FEN.length > 0) {
+      if (this.Protocol == "UCI") {
+        this.PostMessage(`position fen ${FEN} moves ${Moves}`);
+      } else if (this.Protocol == "USI") {
+        this.PostMessage(
+          `position sfen ${ConvertFENtoSFEN(FEN)} moves ${convertUCImovestoUSImoves(Moves, BoardWidth, BoardHeight)}`,
+        );
+      } else if (this.Protocol == "UCCI" || this.Protocol == "UCI_CYCLONE") {
+        this.PostMessage(
+          `position fen ${FEN} moves ${convertUCImovestoUCCImoves(Moves, BoardWidth, BoardHeight)}`,
+        );
+      }
+    } else {
+      if (Moves.length > 0) {
+        if (this.Protocol == "UCI") {
+          this.PostMessage(`position startpos moves ${Moves}`);
+        } else if (this.Protocol == "USI") {
+          this.PostMessage(
+            `position startpos moves ${convertUCImovestoUSImoves(Moves, BoardWidth, BoardHeight)}`,
+          );
+        } else if (this.Protocol == "UCCI" || this.Protocol == "UCI_CYCLONE") {
+          this.PostMessage(
+            `position startpos moves ${convertUCImovestoUCCImoves(Moves, BoardWidth, BoardHeight)}`,
+          );
+        }
+      } else {
+        this.PostMessage(`position startpos`);
+      }
+    }
+  }
+
+  SetVariant(VariantID) {
+    if (typeof VariantID != "string") {
+      throw TypeError();
+    }
+    this.RecordedMultiplePrincipalVariation = 0;
+    if (this.Variants.includes(VariantID)) {
+      if (this.HasVariantsOption) {
+        if (this.Protocol == "UCI" || this.Protocol == "UCI_CYCLONE") {
+          this.PostMessage(`setoption name UCI_Variant value ${VariantID}`);
+        } else if (this.Protocol == "USI") {
+          this.PostMessage(`setoption name USI_Variant value ${VariantID}`);
+        } else if (this.Protocol == "UCCI") {
+          this.PostMessage(`setoption UCCI_Variant ${VariantID}`);
+        }
+      }
+      this.PostMessage("position startpos");
+      this.IsUsing = true;
+      return true;
+    } else {
+      this.IsUsing = false;
+      return false;
+    }
+  }
+
+  CommitMove() {
+    if (!this.IsUsing) {
+      return;
+    }
+    console.log(`${this.Color}: Commit move: ${this.Move}`);
+    if (EnginePlaysColor(this.Color)) {
+      MakeMoveOnBoard(this.Move);
+    }
+  }
+
+  SetMoveInUCIFormat(move) {
+    if (!this.IsUsing) {
+      return;
+    }
+    if (typeof move != "string") {
+      throw TypeError();
+    }
+    if (this.Protocol == "UCI") {
+      this.Move = move;
+    } else if (this.Protocol == "USI") {
+      this.Move = convertUSImovestoUCImoves(
+        move,
+        GetBoardWidth(),
+        GetBoardHeight(),
+      );
+    } else if (this.Protocol == "UCCI" || this.Protocol == "UCI_CYCLONE") {
+      this.Move = convertUCCImovestoUCImoves(
+        move,
+        GetBoardWidth(),
+        GetBoardHeight(),
+      );
+    }
+  }
+
+  SetPonderMoveInUCIFormat(move) {
+    if (!this.IsUsing) {
+      return;
+    }
+    if (typeof move != "string" && move !== undefined) {
+      throw TypeError();
+    }
+    if (move) {
+      if (this.Protocol == "UCI") {
+        this.PonderMove = move;
+      } else if (this.Protocol == "USI") {
+        this.PonderMove = convertUSImovestoUCImoves(
+          move,
+          GetBoardWidth(),
+          GetBoardHeight(),
+        );
+      } else if (this.Protocol == "UCCI" || this.Protocol == "UCI_CYCLONE") {
+        this.PonderMove = convertUCCImovestoUCImoves(
+          move,
+          GetBoardWidth(),
+          GetBoardHeight(),
+        );
+      }
+    } else {
+      this.PonderMove = undefined;
+    }
+  }
+
+  StopThinking(InterruptPondering, IsAdvancedTimeControl) {
+    if (
+      typeof InterruptPondering != "boolean" ||
+      typeof IsAdvancedTimeControl != "boolean"
+    ) {
+      throw TypeError();
+    }
+    if (InterruptPondering || !IsAdvancedTimeControl) {
+      this.PonderMove = "0000";
+      this.PonderMiss = false;
+      this.PostMessage("stop");
+    } else {
+      if (this.Ponder) {
+        //this.PonderMiss = false;
+        this.PostMessage("stop");
+      }
+    }
+  }
+
+  StartThinking(
+    CurrentPlayer,
+    IsAdvancedTimeControl,
+    IsPonder,
+    IsPonderHit,
+    IsByoyomi,
+    Depth,
+    MoveTime,
+    Nodes,
+    WhiteRemainingTime,
+    WhiteTimeGain,
+    BlackRemainingTime,
+    BlackTimeGain,
+    ByoyomiPeriodLength,
+  ) {
+    if (
+      typeof CurrentPlayer != "string" ||
+      typeof IsAdvancedTimeControl != "boolean" ||
+      typeof IsPonder != "boolean" ||
+      typeof IsPonderHit != "boolean" ||
+      typeof IsByoyomi != "boolean" ||
+      typeof Depth != "number" ||
+      typeof MoveTime != "number" ||
+      typeof Nodes != "number" ||
+      typeof WhiteRemainingTime != "number" ||
+      typeof WhiteTimeGain != "number" ||
+      typeof BlackRemainingTime != "number" ||
+      typeof BlackTimeGain != "number" ||
+      typeof ByoyomiPeriodLength != "number"
+    ) {
+      throw TypeError();
+    }
+    if (!this.IsUsing) {
+      return;
+    }
+    this.RecordedMultiplePrincipalVariation = 0;
+    let CurrentPlayerColor = CurrentPlayer.toUpperCase();
+    if (this.IsAnalysisEngine) {
+      this.PostMessage("go infinite");
+    } else if (IsAdvancedTimeControl) {
+      let cmd = "";
+      if (IsPonderHit) {
+        cmd = "ponderhit";
+      } else {
+        cmd = "go";
+      }
+      if (!IsPonderHit && IsPonder) {
+        cmd += " ponder";
+      }
+      if (this.Protocol == "UCCI") {
+        if (CurrentPlayerColor == "WHITE") {
+          if (this.Color == CurrentPlayerColor) {
+            if (IsByoyomi && this.SupportsByoyomi) {
+              cmd += ` time ${WhiteRemainingTime} oppotime ${BlackRemainingTime} byoyomi ${ByoyomiPeriodLength}`;
+            } else {
+              cmd += ` time ${WhiteRemainingTime} increment ${WhiteTimeGain} oppotime ${BlackRemainingTime} oppoincrement ${BlackTimeGain}`;
+            }
+          } else {
+            if (IsByoyomi && this.SupportsByoyomi) {
+              cmd += ` time ${BlackRemainingTime} oppotime ${WhiteRemainingTime} byoyomi ${ByoyomiPeriodLength}`;
+            } else {
+              cmd += ` time ${BlackRemainingTime} increment ${BlackTimeGain} oppotime ${WhiteRemainingTime} oppoincrement ${WhiteTimeGain}`;
+            }
+          }
+        } else if (CurrentPlayerColor == "BLACK") {
+          if (this.Color == CurrentPlayerColor) {
+            if (IsByoyomi && this.SupportsByoyomi) {
+              cmd += ` time ${BlackRemainingTime} oppotime ${WhiteRemainingTime} byoyomi ${ByoyomiPeriodLength}`;
+            } else {
+              cmd += ` time ${BlackRemainingTime} increment ${BlackTimeGain} oppotime ${WhiteRemainingTime} oppoincrement ${WhiteTimeGain}`;
+            }
+          } else {
+            if (IsByoyomi && this.SupportsByoyomi) {
+              cmd += ` time ${WhiteRemainingTime} oppotime ${BlackRemainingTime} byoyomi ${ByoyomiPeriodLength}`;
+            } else {
+              cmd += ` time ${WhiteRemainingTime} increment ${WhiteTimeGain} oppotime ${BlackRemainingTime} oppoincrement ${BlackTimeGain}`;
+            }
+          }
+        }
+      } else {
+        if (IsByoyomi && this.SupportsByoyomi) {
+          cmd += ` wtime ${WhiteRemainingTime} btime ${BlackRemainingTime} byoyomi ${ByoyomiPeriodLength}`;
+        } else {
+          cmd += ` wtime ${WhiteRemainingTime} winc ${WhiteTimeGain} btime ${BlackRemainingTime} binc ${BlackTimeGain}`;
+        }
+      }
+      this.PostMessage(cmd);
+    } else {
+      let args = "";
+      //console.log(Depth, MoveTime, Nodes);
+      if (Depth > 0) {
+        args += ` depth ${Depth}`;
+      }
+      if (MoveTime > 0) {
+        args += ` movetime ${MoveTime}`;
+      }
+      if (Nodes > 0) {
+        args += ` nodes ${Nodes}`;
+      }
+      this.PostMessage(`go${args}`);
+    }
+  }
+
+  SetID(ID, SetIDCallBack) {
+    if (
+      typeof ID != "string" ||
+      (typeof SetIDCallBack != "function" && SetIDCallBack !== undefined)
+    ) {
+      throw TypeError();
+    }
+    let OldID = this.ID;
+    this.SetIDCallBack = SetIDCallBack;
+    this.ID = ID;
+    this.WebSocketConnection.send(`CHANGE_ID|${OldID}|${this.Color}|${ID}`);
+  }
+
+  SetPonderMiss() {
+    this.PonderMiss = true;
+    this.PostMessage("stop");
+    let position = GetBoardPosition();
+    this.SetPosition(
+      position.fen,
+      position.moves,
+      GetBoardWidth(),
+      GetBoardHeight(),
+    );
+  }
+
+  IsReady(IsReadyCallBack) {
+    if (typeof IsReadyCallBack != "function" && IsReadyCallBack !== undefined) {
+      throw TypeError();
+    }
+    this.IsReadyCallBack = IsReadyCallBack;
+    this.PostMessage("isready");
+  }
+
+  WebSocketOnMessageHandler(event) {
+    this.OnReceivedMessageFromServer(event.data);
+  }
+
+  WebSocketOnSocketInvalidHandler(event) {
+    this.IsUsing = false;
+    this.IsLoaded = false;
+    this.IsLoading = false;
+  }
+}
+
+window.fairyground.BinaryEngineFeature.Engine = Engine;
+
+function ShowEditEngineOptionsUI(EngineClass, DestructOnClose) {
+  if (
+    !Engine.prototype.isPrototypeOf(EngineClass) ||
+    typeof DestructOnClose != "boolean"
+  ) {
+    throw TypeError();
+  }
+  if (!EngineClass.IsLoaded) {
+    throw Error("Engine is not loaded.");
+  }
+  while (document.getElementById("enginesettingspopup") != null) {
+    document.getElementById("enginesettingspopup").remove();
+  }
+  if (window.fairyground.BinaryEngineFeature.WebSocketStatus != "CONNECTED") {
+    return;
+  }
+  window.fairyground.BinaryEngineFeature.changing_engine_settings = true;
+  let popup = document.createElement("div");
+  popup.id = "enginesettingspopup";
+  let title = document.createElement("p");
+  title.id = "popup-title";
+  title.innerHTML =
+    "Name: " + EngineClass.Name + "\nAuthor: " + EngineClass.Author;
+  title.style.whiteSpace = "pre-line";
+  title.style.fontSize = "30px";
+  title.style.fontWeight = "bold";
+  title.style.fontFamily = "Times New Roman";
+  title.style.fontStyle = "italic";
+  popup.appendChild(title);
+  let subdiv;
+  let text;
+  let input;
+  let btntext;
+  let restrictiontext;
+  EngineClass.Options.forEach((value, index) => {
+    subdiv = document.createElement("div");
+    subdiv.id = value.name.replace(/[ ]/g, "") + "-div";
+    text = document.createElement("p");
+    text.innerHTML = value.name;
+    subdiv.appendChild(text);
+    if (value.type == "string") {
+      input = document.createElement("input");
+      input.value = value.default;
+      subdiv.appendChild(input);
+    } else if (value.type == "check") {
+      input = document.createElement("input");
+      input.type = "checkbox";
+      if (value.default == "true") {
+        input.checked = true;
+      } else {
+        input.checked = false;
+      }
+      subdiv.appendChild(input);
+    } else if (value.type == "spin") {
+      input = document.createElement("input");
+      input.type = "number";
+      input.max = value.max;
+      input.min = value.min;
+      input.value = value.default;
+      input.onchange = function () {
+        if (
+          !/^(\-|\+)?(0|[1-9][0-9]*)$/.test(
+            document.getElementById(value.name.replace(/[ ]/g, "") + "-input")
+              .value,
+          )
+        ) {
+          document.getElementById(
+            value.name.replace(/[ ]/g, "") + "-input",
+          ).value = parseInt(value.default);
+        } else if (
+          document.getElementById(value.name.replace(/[ ]/g, "") + "-input")
+            .value < parseInt(value.min)
+        ) {
+          document.getElementById(
+            value.name.replace(/[ ]/g, "") + "-input",
+          ).value = parseInt(value.min);
+        } else if (
+          document.getElementById(value.name.replace(/[ ]/g, "") + "-input")
+            .value > parseInt(value.max)
+        ) {
+          document.getElementById(
+            value.name.replace(/[ ]/g, "") + "-input",
+          ).value = parseInt(value.max);
+        }
+      };
+      subdiv.appendChild(input);
+      restrictiontext = document.createElement("p");
+      restrictiontext.innerText = `(Min: ${value.min}, Max: ${value.max})`;
+      subdiv.appendChild(restrictiontext);
+    } else if (value.type == "button") {
+      input = document.createElement("button");
+      input.onclick = function () {
+        EngineClass.SetButtonOption(value.name);
+      };
+      btntext = document.createTextNode(value.name);
+      input.appendChild(btntext);
+      subdiv.appendChild(input);
+    } else if (value.type == "combo") {
+      input = document.createElement("select");
+      let option;
+      value.values.forEach((opt) => {
+        option = document.createElement("option");
+        option.text = opt;
+        option.value = opt;
+        input.appendChild(option);
+      });
+      subdiv.appendChild(input);
+      input.childNodes.forEach((combooption, comboindex) => {
+        if (combooption.innerHTML == EngineClass.Options[index].default) {
+          input.selectedIndex = comboindex;
+        }
+      });
+    } else {
+      console.warn("Unknown option type: ", value.type);
+    }
+    input.id = value.name.replace(/[ ]/g, "") + "-input";
+    subdiv.style.display = "flex";
+    subdiv.style.marginTop = "10px";
+    popup.appendChild(subdiv);
+  });
+  let cancel = document.createElement("button");
+  let canceltext = document.createTextNode("Close");
+  cancel.appendChild(canceltext);
+  cancel.onclick = function () {
+    while (document.getElementById("enginesettingspopup") != null) {
+      document.getElementById("enginesettingspopup").remove();
+    }
+    window.fairyground.BinaryEngineFeature.changing_engine_settings = false;
+    if (DestructOnClose) {
+      EngineClass.destructor();
+    }
+  };
+  let save = document.createElement("button");
+  let savetext = document.createTextNode("Apply Changes");
+  save.onclick = function () {
+    let Elem = null;
+    EngineClass.Options.forEach((value, index) => {
+      if (value.type == "button") {
+        return;
+      }
+      Elem = document.getElementById(value.name.replace(/[ ]/g, "") + "-input");
+      if (Elem == null) {
+        return;
+      }
+      if (value.type == "check") {
+        EngineClass.Options[index].current = Elem.checked.toString();
+        if (
+          value.name == "Ponder" ||
+          value.name == "USI_Ponder" ||
+          value.name == "UCCI_Ponder"
+        ) {
+          if (Elem.checked) {
+            EngineClass.Ponder = true;
+          } else {
+            EngineClass.Ponder = false;
+          }
+        }
+      } else {
+        EngineClass.Options[index].current = Elem.value.toString();
+      }
+    });
+    EngineClass.SetOptions(EngineClass.Options);
+    /*EngineClass.IsReady(() => {
+            console.log("readyok");
+        });*/
+    //console.log(EngineClass.Options);
+    cancel.click();
+  };
+  save.appendChild(savetext);
+  popup.appendChild(save);
+  let showcurrent = document.createElement("button");
+  let showcurrenttext = document.createTextNode("Show Current Value");
+  showcurrent.onclick = function () {
+    let Elem = null;
+    EngineClass.Options.forEach((value, index) => {
+      if (value.type == "button") {
+        return;
+      }
+      Elem = document.getElementById(value.name.replace(/[ ]/g, "") + "-input");
+      if (Elem == null || value.current == null) {
+        return;
+      }
+      if (value.type == "check") {
+        if (EngineClass.Options[index].current == "true") {
+          Elem.checked = true;
+        } else {
+          Elem.checked = false;
+        }
+      } else if (value.type == "spin") {
+        Elem.value = parseInt(EngineClass.Options[index].current);
+      } else if (value.type == "combo") {
+        Elem.childNodes.forEach((combooption, comboindex) => {
+          if (combooption.innerHTML == EngineClass.Options[index].current) {
+            Elem.selectedIndex = comboindex;
+          }
+        });
+      } else {
+        Elem.value = EngineClass.Options[index].current;
+      }
+    });
+    //console.log(EngineClass.Options);
+  };
+  showcurrent.appendChild(showcurrenttext);
+  popup.appendChild(showcurrent);
+  let showdefault = document.createElement("button");
+  let showdefaulttext = document.createTextNode("Show Default Value");
+  showdefault.onclick = function () {
+    let Elem = null;
+    EngineClass.Options.forEach((value, index) => {
+      if (value.type == "button") {
+        return;
+      }
+      Elem = document.getElementById(value.name.replace(/[ ]/g, "") + "-input");
+      if (Elem == null || value.default == null) {
+        return;
+      }
+      if (value.type == "check") {
+        if (EngineClass.Options[index].default == "true") {
+          Elem.checked = true;
+        } else {
+          Elem.checked = false;
+        }
+      } else if (value.type == "spin") {
+        Elem.value = parseInt(EngineClass.Options[index].default);
+      } else if (value.type == "combo") {
+        Elem.childNodes.forEach((combooption, comboindex) => {
+          if (combooption.innerHTML == EngineClass.Options[index].default) {
+            Elem.selectedIndex = comboindex;
+          }
+        });
+      } else {
+        Elem.value = EngineClass.Options[index].default;
+      }
+    });
+    //console.log(EngineClass.Options);
+  };
+  showdefault.appendChild(showdefaulttext);
+  popup.appendChild(showdefault);
+  /*
+    let postmsg = document.createElement("button");
+    let postmsgtext = document.createTextNode("Post Message To Engine");
+    postmsg.appendChild(postmsgtext);
+    postmsg.onclick = function () {
+        let str = prompt("Enter the command that you want to send to the engine.\nBe aware that do not enter any setoption or other commands that changes the settings of the engine, as it will make the values in the GUI differ from engine's settings and can cause problems.");
+        if (str == null || str == "") {
+            return;
+        }
+        if (GetEngineSettingsUIEngineColor() == "WHITE") {
+            PostMessageToEngine("WHITE", str, true);
+        }
+        else if (GetEngineSettingsUIEngineColor() == "BLACK") {
+            PostMessageToEngine("BLACK", str, true);
+        }
+    }
+    popup.appendChild(postmsg);*/
+  popup.appendChild(cancel);
+  popup.style.display = "block";
+  popup.style.zIndex = "1003";
+  document.body.appendChild(popup);
+  showcurrent.click();
+}
+
+window.fairyground.BinaryEngineFeature.ShowEditEngineOptionsUI =
+  ShowEditEngineOptionsUI;
+
+function ShowEngineSetupUI(EngineList, EngineClass, DestructOnClose, ws) {
+  if (
+    (!Engine.prototype.isPrototypeOf(EngineClass) &&
+      EngineClass !== undefined) ||
+    !WebSocket.prototype.isPrototypeOf(ws) ||
+    typeof DestructOnClose != "boolean" ||
+    !Array.isArray(EngineList)
+  ) {
+    throw TypeError();
+  }
+  if (ws.readyState != ws.OPEN) {
+    throw Error("WebSocket connetion error");
+  }
+  while (document.getElementById("enginesetuppopup") != null) {
+    document.getElementById("enginesetuppopup").remove();
+  }
+  if (window.fairyground.BinaryEngineFeature.WebSocketStatus != "CONNECTED") {
+    return;
+  }
+  if (EngineClass) {
+    if (!EngineClass.IsLoaded) {
+      throw Error("Engine is not loaded.");
+    }
+  }
+  let newengineobj = undefined;
+  let isloadingengine = false;
+  let popup = document.createElement("div");
+  popup.id = "enginesetuppopup";
+  let title = document.createElement("p");
+  title.id = "popup-title";
+  title.innerHTML = "Engine Setup";
+  title.style.whiteSpace = "pre-line";
+  title.style.fontSize = "50px";
+  title.style.fontWeight = "bold";
+  title.style.fontFamily = "Times New Roman";
+  title.style.fontStyle = "italic";
+  popup.appendChild(title);
+  let iddiv = document.createElement("div");
+  iddiv.style.display = "flex";
+  let engineidtext = document.createElement("p");
+  engineidtext.innerText = "Engine Display Name (must be unique):";
+  let engineid = document.createElement("input");
+  engineid.style.border = "1px solid #ddd";
+  engineid.style.width = "500px";
+  iddiv.appendChild(engineidtext);
+  iddiv.appendChild(engineid);
+  iddiv.style.marginBottom = "5px";
+  popup.appendChild(iddiv);
+  let pathdiv = document.createElement("div");
+  pathdiv.style.display = "flex";
+  let enginepathtext = document.createElement("p");
+  enginepathtext.innerText = "Engine Excutable Path (Absolute Path):";
+  let enginepath = document.createElement("input");
+  enginepath.style.border = "1px solid #ddd";
+  enginepath.style.width = "500px";
+  pathdiv.appendChild(enginepathtext);
+  pathdiv.appendChild(enginepath);
+  pathdiv.style.marginBottom = "5px";
+  popup.appendChild(pathdiv);
+  let wddiv = document.createElement("div");
+  wddiv.style.display = "flex";
+  let enginewdtext = document.createElement("p");
+  enginewdtext.innerText = "Engine Working Directory (Absolute Path):";
+  let enginewd = document.createElement("input");
+  enginewd.style.border = "1px solid #ddd";
+  enginewd.style.width = "500px";
+  enginewd.placeholder =
+    "Leave blank to be the same with Excutable Path directory";
+  wddiv.appendChild(enginewdtext);
+  wddiv.appendChild(enginewd);
+  wddiv.style.marginBottom = "5px";
+  popup.appendChild(wddiv);
+  let protocoldiv = document.createElement("div");
+  protocoldiv.style.display = "flex";
+  let engineprotocoltext = document.createElement("p");
+  engineprotocoltext.innerText = "Engine Protocol:";
+  let engineprotocol = document.createElement("select");
+  engineprotocol.style.background = "#eee";
+  engineprotocol.style.width = "400px";
+  let option = document.createElement("option");
+  option.text = "UCI (Universal Chess Interface)";
+  option.value = "UCI";
+  engineprotocol.appendChild(option);
+  option = document.createElement("option");
+  option.text = "UCCI (Universal Chinese Chess Interface)";
+  option.value = "UCCI";
+  engineprotocol.appendChild(option);
+  option = document.createElement("option");
+  option.text = "USI (Universal Shogi Interface)";
+  option.value = "USI";
+  engineprotocol.appendChild(option);
+  option = document.createElement("option");
+  option.text = "UCI: Cyclone (Universal Chess Interface Cyclone Variation)";
+  option.value = "UCI_CYCLONE";
+  engineprotocol.appendChild(option);
+  protocoldiv.appendChild(engineprotocoltext);
+  protocoldiv.appendChild(engineprotocol);
+  protocoldiv.style.marginBottom = "5px";
+  popup.appendChild(protocoldiv);
+  if (EngineClass) {
+    engineid.value = EngineClass.ID;
+    enginepath.value = EngineClass.Command;
+    enginewd.value = EngineClass.WorkingDirectory;
+    let index = ["UCI", "UCCI", "USI", "UCI_CYCLONE"];
+    engineprotocol.selectedIndex = index.indexOf(EngineClass.Protocol);
+    //engineid.disabled = true;
+  }
+  let optionsdiv = document.createElement("div");
+  optionsdiv.style.display = "flex";
+  let engineoptionstext = document.createElement("p");
+  engineoptionstext.innerText = "Engine Options:";
+  let engineoptions = document.createElement("button");
+  engineoptions.onclick = function () {
+    if (isloadingengine) {
+      window.alert("Engine is loading.");
+      return;
+    }
+    if (EngineClass) {
+      if (
+        enginepath.value.trim() == EngineClass.Command.trim() &&
+        engineprotocol[engineprotocol.selectedIndex].value ==
+          EngineClass.Protocol &&
+        enginewd.value == EngineClass.WorkingDirectory
+      ) {
+        ShowEditEngineOptionsUI(EngineClass, false);
+      } else {
+        EngineClass.destructor();
+        EngineClass = undefined;
+        isloadingengine = true;
+        EngineClass = new Engine(
+          engineid.value,
+          enginepath.value,
+          enginewd.value,
+          engineprotocol[engineprotocol.selectedIndex].value,
+          [],
+          "",
+          window.fairyground.BinaryEngineFeature.load_engine_timeout,
+          ws,
+        );
+        EngineClass.Load(
+          () => {
+            ShowEditEngineOptionsUI(EngineClass, false);
+            isloadingengine = false;
+          },
+          (err) => {
+            console.error(`Cannot load engine: ${err}`);
+            window.alert(`Cannot load engine: ${err}`);
+            isloadingengine = false;
+          },
+        );
+      }
+    } else {
+      if (engineid.value == "" || enginepath.value == "") {
+        window.alert("Engine ID and excutable path must not be null");
+        return;
+      }
+      if (newengineobj) {
+        if (newengineobj.IsLoaded) {
+          if (
+            enginepath.value.trim() == newengineobj.Command.trim() &&
+            engineprotocol[engineprotocol.selectedIndex].value ==
+              newengineobj.Protocol &&
+            enginewd.value == newengineobj.WorkingDirectory
+          ) {
+            ShowEditEngineOptionsUI(newengineobj, false);
+            return;
+          } else {
+            newengineobj.destructor();
+            newengineobj = undefined;
+          }
+        } else if (newengineobj.IsLoading) {
+          window.alert("The engine is loading. Please wait for some time.");
+          return;
+        } else {
+          newengineobj.destructor();
+          newengineobj = undefined;
+        }
+      }
+      isloadingengine = true;
+      newengineobj = new Engine(
+        engineid.value,
+        enginepath.value,
+        enginewd.value,
+        engineprotocol[engineprotocol.selectedIndex].value,
+        [],
+        "",
+        window.fairyground.BinaryEngineFeature.load_engine_timeout,
+        ws,
+      );
+      newengineobj.Load(
+        () => {
+          ShowEditEngineOptionsUI(newengineobj, false);
+          isloadingengine = false;
+        },
+        (err) => {
+          console.error(`Cannot load engine: ${err}`);
+          window.alert(`Cannot load engine: ${err}`);
+          isloadingengine = false;
+        },
+      );
+    }
+  };
+  let btntxt = document.createTextNode("Edit Options...");
+  engineoptions.appendChild(btntxt);
+  optionsdiv.appendChild(engineoptionstext);
+  optionsdiv.appendChild(engineoptions);
+  optionsdiv.style.marginBottom = "5px";
+  popup.appendChild(optionsdiv);
+  let actiondiv = document.createElement("div");
+  actiondiv.style.display = "flex";
+  let cancel = document.createElement("button");
+  let canceltext = document.createTextNode("Cancel");
+  cancel.onclick = function () {
+    if (isloadingengine) {
+      window.alert("Engine is loading.");
+      return;
+    }
+    if (DestructOnClose) {
+      if (EngineClass) {
+        EngineClass.destructor();
+      }
+    }
+    if (newengineobj) {
+      newengineobj.destructor();
+      newengineobj = undefined;
+    }
+    while (document.getElementById("enginesetuppopup") != null) {
+      document.getElementById("enginesetuppopup").remove();
+    }
+  };
+  cancel.appendChild(canceltext);
+  let confirm = document.createElement("button");
+  let confirmtext = document.createTextNode("");
+  if (EngineClass) {
+    confirmtext.textContent = "Save Changes";
+  } else {
+    confirmtext.textContent = "Add Engine";
+  }
+  confirm.onclick = function () {
+    if (engineid.value == "" || enginepath.value == "") {
+      window.alert("Engine ID and excutable path must not be null");
+      return;
+    }
+    if (isloadingengine) {
+      window.alert("Engine is loading.");
+      return;
+    }
+    if (
+      EngineClass !== undefined &&
+      EngineClass.IsLoaded &&
+      enginepath.value.trim() == EngineClass.Command.trim() &&
+      engineprotocol[engineprotocol.selectedIndex].value ==
+        EngineClass.Protocol &&
+      enginewd.value == EngineClass.WorkingDirectory
+    ) {
+      if (engineid.value != EngineClass.ID) {
+        if (
+          !window.confirm(
+            `The ID has been changed to "${engineid.value}", which is different from the original one (${EngineClass.ID}). If you save the changes, it will be saved as a new engine while the original engine won't be changed. Proceed?`,
+          )
+        ) {
+          return;
+        }
+      }
+      EngineClass.SetID(engineid.value);
+      EngineClass.Command = enginepath.value;
+      EngineClass.Protocol = engineprotocol[engineprotocol.selectedIndex].value;
+      EngineClass.WorkingDirectory = enginewd.value;
+      EngineClass.SaveOptionsToEngineList(EngineList);
+      if (window.fairyground.BinaryEngineFeature.first_engine) {
+        if (
+          window.fairyground.BinaryEngineFeature.first_engine.ID ==
+          EngineClass.ID
+        ) {
+          window.fairyground.BinaryEngineFeature.first_engine.SetOptions(
+            EngineClass.Options,
+          );
+        }
+      }
+      if (window.fairyground.BinaryEngineFeature.second_engine) {
+        if (
+          window.fairyground.BinaryEngineFeature.second_engine.ID ==
+          EngineClass.ID
+        ) {
+          window.fairyground.BinaryEngineFeature.second_engine.SetOptions(
+            EngineClass.Options,
+          );
+        }
+      }
+      if (window.fairyground.BinaryEngineFeature.analysis_engine) {
+        if (
+          window.fairyground.BinaryEngineFeature.analysis_engine.ID ==
+          EngineClass.ID
+        ) {
+          window.fairyground.BinaryEngineFeature.analysis_engine.SetOptions(
+            EngineClass.Options,
+          );
+        }
+      }
+    } else if (
+      newengineobj !== undefined &&
+      newengineobj.IsLoaded &&
+      enginepath.value.trim() == newengineobj.Command.trim() &&
+      engineprotocol[engineprotocol.selectedIndex].value ==
+        newengineobj.Protocol &&
+      enginewd.value == newengineobj.WorkingDirectory
+    ) {
+      if (GetEngineItem(EngineList, engineid.value)) {
+        window.alert(
+          `Engine with name "${engineid.value}" already exists. Please enter a different name.`,
+        );
+        return;
+      }
+      newengineobj.SetID(engineid.value);
+      newengineobj.SaveOptionsToEngineList(EngineList);
+    } else {
+      window.alert(
+        "The engine hasn't been verified yet. Click <Edit Options...> to check validity.",
+      );
+      return;
+    }
+    let availableenginesdropdown = document.getElementById(
+      "availableenginesdropdown",
+    );
+    if (availableenginesdropdown) {
+      while (availableenginesdropdown.length > 0) {
+        availableenginesdropdown.removeChild(availableenginesdropdown[0]);
+      }
+      EngineList.forEach((val) => {
+        let option = document.createElement("option");
+        option.text = val.id;
+        option.value = val.id;
+        availableenginesdropdown.appendChild(option);
+      });
+    }
+    cancel.click();
+  };
+  confirm.appendChild(confirmtext);
+  actiondiv.appendChild(confirm);
+  actiondiv.appendChild(cancel);
+  popup.appendChild(actiondiv);
+  popup.style.display = "block";
+  popup.style.zIndex = "1002";
+  document.body.appendChild(popup);
+}
+
+window.fairyground.BinaryEngineFeature.ShowEngineSetupUI = ShowEngineSetupUI;
+
+function ShowEngineManagementUI(EngineList, ws) {
+  if (!WebSocket.prototype.isPrototypeOf(ws) || !Array.isArray(EngineList)) {
+    throw TypeError();
+  }
+  if (ws.readyState != ws.OPEN) {
+    throw Error("WebSocket connetion error");
+  }
+  while (document.getElementById("enginemanagementpopup") != null) {
+    document.getElementById("enginemanagementpopup").remove();
+  }
+  if (window.fairyground.BinaryEngineFeature.WebSocketStatus != "CONNECTED") {
+    return;
+  }
+  let isloadingengine = false;
+  let popup = document.createElement("div");
+  popup.id = "enginemanagementpopup";
+  let title = document.createElement("p");
+  title.id = "popup-title";
+  title.innerHTML = "Engine Management";
+  title.style.whiteSpace = "pre-line";
+  title.style.fontSize = "50px";
+  title.style.fontWeight = "bold";
+  title.style.fontFamily = "Times New Roman";
+  title.style.fontStyle = "italic";
+  popup.appendChild(title);
+  let engineinfodiv = document.createElement("div");
+  let enginelistdiv = document.createElement("div");
+  let enginecontroldiv = document.createElement("div");
+  enginelistdiv.style.display = "flex";
+  enginecontroldiv.style.display = "flex";
+  engineinfodiv.style.display = "flex";
+  engineinfodiv.style.flexDirection = "column";
+  let whiteengineinfo = document.createElement("p");
+  if (window.fairyground.BinaryEngineFeature.first_engine) {
+    whiteengineinfo.innerText = `First Engine (WHITE) → ID: ${window.fairyground.BinaryEngineFeature.first_engine.ID} Name: ${window.fairyground.BinaryEngineFeature.first_engine.Name} Author: ${window.fairyground.BinaryEngineFeature.first_engine.Author}`;
+  } else {
+    whiteengineinfo.innerText = "First Engine (WHITE) → (Not Loaded)";
+  }
+  engineinfodiv.appendChild(whiteengineinfo);
+  let blackengineinfo = document.createElement("p");
+  if (window.fairyground.BinaryEngineFeature.second_engine) {
+    blackengineinfo.innerText = `Second Engine (BLACK) → ID: ${window.fairyground.BinaryEngineFeature.second_engine.ID} Name: ${window.fairyground.BinaryEngineFeature.second_engine.Name} Author: ${window.fairyground.BinaryEngineFeature.second_engine.Author}`;
+  } else {
+    blackengineinfo.innerText = "Second Engine (BLACK) → (Not Loaded)";
+  }
+  engineinfodiv.appendChild(blackengineinfo);
+  let analysisengineinfo = document.createElement("p");
+  if (window.fairyground.BinaryEngineFeature.analysis_engine) {
+    analysisengineinfo.innerText = `Analysis Engine (ANALYSIS) → ID: ${window.fairyground.BinaryEngineFeature.analysis_engine.ID} Name: ${window.fairyground.BinaryEngineFeature.analysis_engine.Name} Author: ${window.fairyground.BinaryEngineFeature.analysis_engine.Author}`;
+  } else {
+    analysisengineinfo.innerText = "Analysis Engine (ANALYSIS) → (Not Loaded)";
+  }
+  engineinfodiv.appendChild(analysisengineinfo);
+  let availableenginestext = document.createElement("p");
+  availableenginestext.innerText = "Available Engines:";
+  let availableenginesdropdown = document.createElement("select");
+  availableenginesdropdown.id = "availableenginesdropdown";
+  EngineList.forEach((val) => {
+    let option = document.createElement("option");
+    option.text = val.id;
+    option.value = val.id;
+    availableenginesdropdown.appendChild(option);
+  });
+  enginelistdiv.appendChild(availableenginestext);
+  enginelistdiv.appendChild(availableenginesdropdown);
+  let addengine = document.createElement("button");
+  addengine.onclick = function () {
+    ShowEngineSetupUI(EngineList, undefined, true, ws);
+  };
+  let addenginetext = document.createTextNode("Add Engine");
+  addengine.appendChild(addenginetext);
+  enginecontroldiv.appendChild(addengine);
+  let removeengine = document.createElement("button");
+  removeengine.onclick = function () {
+    if (availableenginesdropdown.selectedIndex < 0) {
+      window.alert("Please select a engine to remove.");
+      return;
+    }
+    let id =
+      availableenginesdropdown[availableenginesdropdown.selectedIndex].value;
+    RemoveEngineItem(EngineList, id);
+    while (availableenginesdropdown.length > 0) {
+      availableenginesdropdown.removeChild(availableenginesdropdown[0]);
+    }
+    EngineList.forEach((val) => {
+      let option = document.createElement("option");
+      option.text = val.id;
+      option.value = val.id;
+      availableenginesdropdown.appendChild(option);
+    });
+  };
+  let removeenginetext = document.createTextNode("Remove");
+  removeengine.appendChild(removeenginetext);
+  enginecontroldiv.appendChild(removeengine);
+  let editsettings = document.createElement("button");
+  editsettings.onclick = function () {
+    if (availableenginesdropdown.selectedIndex < 0) {
+      window.alert("Please select a engine.");
+      return;
+    }
+    if (isloadingengine) {
+      window.alert("Engine is loading.");
+      return;
+    }
+    let id =
+      availableenginesdropdown[availableenginesdropdown.selectedIndex].value;
+    let enginesettings = GetEngineItem(EngineList, id);
+    isloadingengine = true;
+    let engineobj = new Engine(
+      id,
+      enginesettings.path,
+      enginesettings.working_directory,
+      enginesettings.protocol,
+      enginesettings.options,
+      "",
+      window.fairyground.BinaryEngineFeature.load_engine_timeout,
+      ws,
+    );
+    engineobj.Load(
+      () => {
+        ShowEngineSetupUI(EngineList, engineobj, true, ws);
+        isloadingengine = false;
+      },
+      (err) => {
+        isloadingengine = false;
+        window.alert("Failed to load engine. Reason: " + err);
+      },
+    );
+  };
+  let editsettingstext = document.createTextNode("Change Options");
+  editsettings.appendChild(editsettingstext);
+  enginecontroldiv.appendChild(editsettings);
+  let selectaswhite = document.createElement("button");
+  selectaswhite.onclick = function () {
+    if (window.fairyground.BinaryEngineFeature.first_engine) {
+      if (window.fairyground.BinaryEngineFeature.first_engine.IsLoading) {
+        window.alert("Engine is loading, please wait...");
+        return;
+      }
+      window.fairyground.BinaryEngineFeature.first_engine.destructor();
+    }
+    if (availableenginesdropdown.selectedIndex < 0) {
+      window.alert("Please select a engine.");
+      return;
+    }
+    let id =
+      availableenginesdropdown[availableenginesdropdown.selectedIndex].value;
+    let enginesettings = GetEngineItem(EngineList, id);
+    let engineobj = new Engine(
+      id,
+      enginesettings.path,
+      enginesettings.working_directory,
+      enginesettings.protocol,
+      enginesettings.options,
+      "WHITE",
+      window.fairyground.BinaryEngineFeature.load_engine_timeout,
+      ws,
+    );
+    window.fairyground.BinaryEngineFeature.first_engine = engineobj;
+    engineobj.Load(
+      (name, author) => {
+        whiteengineinfo.innerText = `First Engine (WHITE) → ID: ${id} Name: ${name} Author: ${author}`;
+      },
+      (err) => {
+        whiteengineinfo.innerText = `First Engine (WHITE) → (Not Loaded) (Error: ${err})`;
+      },
+    );
+  };
+  let selectaswhitetext = document.createTextNode("Load As 1st Engine");
+  selectaswhite.appendChild(selectaswhitetext);
+  enginecontroldiv.appendChild(selectaswhite);
+  let selectasblack = document.createElement("button");
+  selectasblack.onclick = function () {
+    if (window.fairyground.BinaryEngineFeature.second_engine) {
+      if (window.fairyground.BinaryEngineFeature.second_engine.IsLoading) {
+        window.alert("Engine is loading, please wait...");
+        return;
+      }
+      window.fairyground.BinaryEngineFeature.second_engine.destructor();
+    }
+    if (availableenginesdropdown.selectedIndex < 0) {
+      window.alert("Please select a engine.");
+      return;
+    }
+    let id =
+      availableenginesdropdown[availableenginesdropdown.selectedIndex].value;
+    let enginesettings = GetEngineItem(EngineList, id);
+    let engineobj = new Engine(
+      id,
+      enginesettings.path,
+      enginesettings.working_directory,
+      enginesettings.protocol,
+      enginesettings.options,
+      "BLACK",
+      window.fairyground.BinaryEngineFeature.load_engine_timeout,
+      ws,
+    );
+    window.fairyground.BinaryEngineFeature.second_engine = engineobj;
+    engineobj.Load(
+      (name, author) => {
+        blackengineinfo.innerText = `Second Engine (BLACK) → ID: ${id} Name: ${name} Author: ${author}`;
+      },
+      (err) => {
+        blackengineinfo.innerText = `Second Engine (BLACK) → (Not Loaded) (Error: ${err})`;
+      },
+    );
+  };
+  let selectasblacktext = document.createTextNode("Load As 2nd Engine");
+  selectasblack.appendChild(selectasblacktext);
+  enginecontroldiv.appendChild(selectasblack);
+  let selectasanalysis = document.createElement("button");
+  selectasanalysis.onclick = function () {
+    if (window.fairyground.BinaryEngineFeature.analysis_engine) {
+      if (window.fairyground.BinaryEngineFeature.analysis_engine.IsLoading) {
+        window.alert("Engine is loading, please wait...");
+        return;
+      }
+      window.fairyground.BinaryEngineFeature.analysis_engine.destructor();
+    }
+    if (availableenginesdropdown.selectedIndex < 0) {
+      window.alert("Please select a engine.");
+      return;
+    }
+    let id =
+      availableenginesdropdown[availableenginesdropdown.selectedIndex].value;
+    let enginesettings = GetEngineItem(EngineList, id);
+    let engineobj = new Engine(
+      id,
+      enginesettings.path,
+      enginesettings.working_directory,
+      enginesettings.protocol,
+      enginesettings.options,
+      "ANALYSIS",
+      window.fairyground.BinaryEngineFeature.load_engine_timeout,
+      ws,
+    );
+    window.fairyground.BinaryEngineFeature.analysis_engine = engineobj;
+    engineobj.Load(
+      (name, author) => {
+        analysisengineinfo.innerText = `Analysis Engine (ANALYSIS) → ID: ${id} Name: ${name} Author: ${author}`;
+      },
+      (err) => {
+        analysisengineinfo.innerText = `Analysis Engine (ANALYSIS) → (Not Loaded) (Error: ${err})`;
+      },
+    );
+  };
+  let selectasanalysistext = document.createTextNode("Load As Analysis Engine");
+  selectasanalysis.appendChild(selectasanalysistext);
+  enginecontroldiv.appendChild(selectasanalysis);
+  popup.appendChild(enginelistdiv);
+  popup.appendChild(enginecontroldiv);
+  popup.appendChild(engineinfodiv);
+  let storagediv = document.createElement("div");
+  storagediv.style.display = "flex";
+  storagediv.style.marginBottom = "5px";
+  let savelist = document.createElement("button");
+  let savelisttext = document.createTextNode("Save Engine List");
+  savelist.appendChild(savelisttext);
+  savelist.onclick = function () {
+    if (
+      !window.confirm(
+        "Save added engines? The saved data will be replaced with current list.",
+      )
+    ) {
+      return;
+    }
+    try {
+      localStorage.setItem(
+        "fairyground-EngineList",
+        ConvertEngineListToText(EngineList),
+      );
+      window.alert("Successfully saved added engines.");
+    } catch (e) {
+      window.alert(`Cannot save list:\n${e}`);
+    }
+  };
+  let loadlist = document.createElement("button");
+  let loadlisttext = document.createTextNode("Load Engine List");
+  loadlist.appendChild(loadlisttext);
+  loadlist.onclick = function () {
+    let listmsg = localStorage.getItem("fairyground-EngineList");
+    if (listmsg) {
+      let newlist = ParseSavedEngineListMessage(listmsg).reverse();
+      EngineList.splice(0, EngineList.length);
+      while (newlist.length > 0) {
+        EngineList.push(newlist.pop());
+      }
+      while (availableenginesdropdown.length > 0) {
+        availableenginesdropdown.removeChild(availableenginesdropdown[0]);
+      }
+      EngineList.forEach((val) => {
+        let option = document.createElement("option");
+        option.text = val.id;
+        option.value = val.id;
+        availableenginesdropdown.appendChild(option);
+      });
+    } else {
+      window.alert(
+        "There is no saved list. Note that the list cannot be accessed if you changed the browser, port, host name or web protocol.",
+      );
+    }
+  };
+  let savelisttofile = document.createElement("button");
+  let savelisttofiletext = document.createTextNode("Save Engine List To File");
+  savelisttofile.appendChild(savelisttofiletext);
+  savelisttofile.onclick = function () {
+    DownloadFile(
+      ConvertEngineListToText(EngineList),
+      "EngineList.txt",
+      "text/plain",
+    );
+  };
+  let loadlistfromfile = document.createElement("button");
+  let loadlistfromfiletext = document.createTextNode(
+    "Load Engine List From File",
+  );
+  loadlistfromfile.appendChild(loadlistfromfiletext);
+  loadlistfromfile.onclick = function () {
+    while (document.getElementById("EngineListFileSelect") != null) {
+      document.getElementById("EngineListFileSelect").remove();
+    }
+    const fileInput = document.createElement("input");
+    fileInput.type = "file";
+    fileInput.id = "EngineListFileSelect";
+    fileInput.style.display = "none";
+    fileInput.addEventListener("change", function (event) {
+      const file = event.target.files[0];
+      if (file && file.type.startsWith("text/")) {
+        const reader = new FileReader();
+
+        reader.onload = function (event) {
+          let text = event.target.result;
+          let newlist = ParseSavedEngineListMessage(text).reverse();
+          EngineList.splice(0, EngineList.length);
+          while (newlist.length > 0) {
+            EngineList.push(newlist.pop());
+          }
+          while (availableenginesdropdown.length > 0) {
+            availableenginesdropdown.removeChild(availableenginesdropdown[0]);
+          }
+          EngineList.forEach((val) => {
+            let option = document.createElement("option");
+            option.text = val.id;
+            option.value = val.id;
+            availableenginesdropdown.appendChild(option);
+          });
+        };
+
+        reader.readAsText(file, "utf-8");
+      }
+    });
+    popup.appendChild(fileInput);
+    fileInput.click();
+  };
+  storagediv.appendChild(loadlist);
+  storagediv.appendChild(savelist);
+  storagediv.appendChild(loadlistfromfile);
+  storagediv.appendChild(savelisttofile);
+  popup.appendChild(storagediv);
+  let cancel = document.createElement("button");
+  let canceltext = document.createTextNode("Close");
+  cancel.appendChild(canceltext);
+  cancel.onclick = function () {
+    if (isloadingengine) {
+      window.alert("Engine is loading, please wait...");
+      return;
+    }
+    const SelectedIndex =
+      document.getElementById("dropdown-variant").selectedIndex;
+    if (window.fairyground.BinaryEngineFeature.first_engine) {
+      if (window.fairyground.BinaryEngineFeature.first_engine.IsLoading) {
+        window.alert("Engine is loading, please wait...");
+        return;
+      }
+      if (
+        window.fairyground.BinaryEngineFeature.first_engine.SetVariant(
+          document.getElementById("dropdown-variant")[SelectedIndex].value,
+        )
+      ) {
+        document.getElementById("whiteunsupportedvariant").hidden = true;
+      } else {
+        document.getElementById("whiteunsupportedvariant").hidden = false;
+      }
+    }
+    if (window.fairyground.BinaryEngineFeature.second_engine) {
+      if (window.fairyground.BinaryEngineFeature.second_engine.IsLoading) {
+        window.alert("Engine is loading, please wait...");
+        return;
+      }
+      if (
+        window.fairyground.BinaryEngineFeature.second_engine.SetVariant(
+          document.getElementById("dropdown-variant")[SelectedIndex].value,
+        )
+      ) {
+        document.getElementById("blackunsupportedvariant").hidden = true;
+      } else {
+        document.getElementById("blackunsupportedvariant").hidden = false;
+      }
+    }
+    if (window.fairyground.BinaryEngineFeature.analysis_engine) {
+      if (window.fairyground.BinaryEngineFeature.analysis_engine.IsLoading) {
+        window.alert("Engine is loading, please wait...");
+        return;
+      }
+      if (
+        window.fairyground.BinaryEngineFeature.analysis_engine.SetVariant(
+          document.getElementById("dropdown-variant")[SelectedIndex].value,
+        )
+      ) {
+        document.getElementById("analysisunsupportedvariant").hidden = true;
+      } else {
+        document.getElementById("analysisunsupportedvariant").hidden = false;
+      }
+    }
+    document.getElementById("binengineoutputinit").click();
+    while (document.getElementById("enginemanagementpopup") != null) {
+      document.getElementById("enginemanagementpopup").remove();
+    }
+  };
+  popup.appendChild(cancel);
+  popup.style.display = "block";
+  popup.style.zIndex = "1001";
+  document.body.appendChild(popup);
+}
+
+window.fairyground.BinaryEngineFeature.ShowEngineManagementUI =
+  ShowEngineManagementUI;

--- a/src/BinaryEngineFeature.js
+++ b/src/BinaryEngineFeature.js
@@ -491,6 +491,8 @@ const PonderOptionSearchRegExp = new RegExp(
 );
 const MessageSplitter = new RegExp("\x10", "");
 const AllBlankTestRegExp = new RegExp("^[ ]*$", "");
+const WhiteSpaceMatcher = new RegExp("[ ]+", "");
+const LineFeedCarriageReturnMatcher = new RegExp("(\r\n)|(\r)", "g");
 
 function GetCurrentVariantID() {
   return document.getElementById("dropdown-variant").value;
@@ -1086,7 +1088,7 @@ class Engine {
       msg[1] == this.ID &&
       msg[2] == this.Color
     ) {
-      this.DataStream += msg[3].replace(/(\r\n)|(\r)/g, "\n");
+      this.DataStream += msg[3].replace(LineFeedCarriageReturnMatcher, "\n");
       let index = this.DataStream.indexOf("\n");
       if (index >= 0) {
         do {
@@ -1149,7 +1151,7 @@ class Engine {
       if (typeof this.OutputUpdateCallBack == "function") {
         this.OutputUpdateCallBack(this.Color, Message);
       }
-      if (Message.startsWith("bestmove")) {
+      if (Message.includes("bestmove")) {
         //console.log(`${this.Color} Receive: ${Message}`);
         //this.IsThinking = false;
         if (this.MoveRightCount <= 0) {
@@ -1163,7 +1165,7 @@ class Engine {
           if (this.Ponder && this.PonderMiss) {
             this.PonderMiss = false;
           } else {
-            let bestmoveline = Message.split(" ");
+            let bestmoveline = Message.trim().split(WhiteSpaceMatcher);
             if (bestmoveline[1] == "resign" || bestmoveline[2] == "resign") {
               if (this.IsAnalysisEngine) {
                 window.alert(
@@ -1282,7 +1284,7 @@ class Engine {
                     this.EvaluationUpdateCallBack(this.RecordedMultiplePrincipalVariation, this.MultiplePrincipalVariationRecord, this.EvaluationIndex, NaN, NaN);
                 }*/
         if (Message.includes(" score ") && Message.includes(" pv ")) {
-          let msglist = Message.split(" ");
+          let msglist = Message.trim().split(WhiteSpaceMatcher);
           let pv = msglist.slice(msglist.indexOf("pv") + 1);
           msglist = msglist.slice(0, msglist.indexOf("pv"));
           let moves = pv.join(" ");
@@ -1304,7 +1306,7 @@ class Engine {
           }
           this.EvaluationUpdateCallBack(msglist.join(" ") + " pv " + moves);
         } else if (Message.includes("bestmove")) {
-          let msglist = Message.split(" ");
+          let msglist = Message.trim().split(WhiteSpaceMatcher);
           let bestmove = msglist[1];
           let ponder = "0000";
           if (msglist[2] == "draw") {

--- a/src/BinaryEngineFeature.js
+++ b/src/BinaryEngineFeature.js
@@ -1246,11 +1246,11 @@ class Engine {
           }
         } else {
           console.error(
-            `Engine ID ${this.ID} Color ${this.Color} makes a move when not in it's turn. If you are not during play in advanced time control mode, you can ignore this message as this can be caused by clicking <stop> or the game finishes. Otherwise this usually can be making a move before "ponderhit" when Ponder=true.`,
+            `Engine ID ${this.ID} Color ${this.Color} makes a move when not in it's turn. If you are not during play in advanced time control mode, you can ignore this message as this can be caused by clicking <stop> or the game finishes/aborts. Otherwise this usually can be making a move before "ponderhit" when Ponder=true.`,
           );
           if (typeof this.OnErrorMessageCallBack == "function") {
             this.OnErrorMessageCallBack(
-              `Error: Engine ${this.Color} makes a move when not in it's turn. This usually can be making a move before "ponderhit" when Ponder=true.`,
+              `Error: Engine ID ${this.ID} Color ${this.Color} makes a move when not in it's turn. This usually can be making a move before "ponderhit" when Ponder=true.`,
             );
           }
         }

--- a/src/BinaryEngineFeature.js
+++ b/src/BinaryEngineFeature.js
@@ -489,7 +489,7 @@ const PonderOptionSearchRegExp = new RegExp(
   "(Ponder)|(UCI_Ponder)|(USI_Ponder)|(UCCI_Ponder)",
   "i",
 );
-const MessageSplitter = new RegExp("(?<!\\\\)\\|", "");
+const MessageSplitter = new RegExp("\x10", "");
 const AllBlankTestRegExp = new RegExp("^[ ]*$", "");
 
 function GetCurrentVariantID() {
@@ -770,7 +770,7 @@ function GetEngineList(GetFinishCallBack, ws) {
     throw Error("WebSocket connetion error");
   }
   function OnGetEngineListMessageReceived(event) {
-    let msg = event.data.split("|");
+    let msg = event.data.split("\x10");
     if (msg[0] == "ENGINE_LIST") {
       let list = ParseSavedEngineListMessage(msg[1]);
       ws.removeEventListener("message", OnGetEngineListMessageReceived);
@@ -791,7 +791,7 @@ function SaveEngineList(EngineList, ws) {
     throw Error("WebSocket connetion error");
   }
   let text = ConvertEngineListToText(EngineList);
-  ws.send(`SAVE_ENGINE_LIST|${text}`);
+  ws.send(`SAVE_ENGINE_LIST\x10${text}`);
 }
 
 window.fairyground.BinaryEngineFeature.SaveEngineList = SaveEngineList;
@@ -1031,7 +1031,9 @@ class Engine {
       this.WebSocketOnSocketInvalidHandlerBinded,
     );
     if (this.WebSocketConnection.readyState == this.WebSocketConnection.OPEN) {
-      this.WebSocketConnection.send(`EXIT_ENGINE|${this.ID}|${this.Color}`);
+      this.WebSocketConnection.send(
+        `EXIT_ENGINE\x10${this.ID}\x10${this.Color}`,
+      );
     }
     this.IsUsing = false;
     this.IsLoaded = false;
@@ -1066,7 +1068,7 @@ class Engine {
     this.LoadFinishCallBack = LoadFinishCallBack;
     this.LoadFailureCallBack = LoadFailureCallBack;
     this.WebSocketConnection.send(
-      `LOAD_ENGINE|${this.ID}|${this.Color}|${this.Protocol}|${this.Command}|${this.WorkingDirectory}|${this.LoadTimeOut}`,
+      `LOAD_ENGINE\x10${this.ID}\x10${this.Color}\x10${this.Protocol}\x10${this.Command}\x10${this.WorkingDirectory}\x10${this.LoadTimeOut}`,
     );
     return true;
   }
@@ -1359,7 +1361,9 @@ class Engine {
         this.SetOptions(this.Options);
         this.MessageBuffer = [];
       } else if (Message.includes("readyok")) {
-        this.WebSocketConnection.send(`ENGINE_READY|${this.ID}|${this.Color}`);
+        this.WebSocketConnection.send(
+          `ENGINE_READY\x10${this.ID}\x10${this.Color}`,
+        );
         this.IsLoaded = true;
         this.IsLoading = false;
         if (this.Variants.includes(GetCurrentVariantID())) {
@@ -1617,7 +1621,7 @@ class Engine {
     //console.log(`Send ${this.Color}: ${Message}`);
     //console.log(Error());
     this.WebSocketConnection.send(
-      `POST_MSG|${this.ID}|${this.Color}|${Message}`,
+      `POST_MSG\x10${this.ID}\x10${this.Color}\x10${Message}`,
     );
   }
 
@@ -2021,7 +2025,9 @@ class Engine {
     let OldID = this.ID;
     this.SetIDCallBack = SetIDCallBack;
     this.ID = ID;
-    this.WebSocketConnection.send(`CHANGE_ID|${OldID}|${this.Color}|${ID}`);
+    this.WebSocketConnection.send(
+      `CHANGE_ID\x10${OldID}\x10${this.Color}\x10${ID}`,
+    );
   }
 
   SetPonderMiss() {

--- a/src/BinaryEngineFeature.js
+++ b/src/BinaryEngineFeature.js
@@ -976,6 +976,7 @@ class Engine {
     this.MultiplePrincipalVariationRecord = [];
     this.EvaluationIndex = [];
     this.IsThinking = false;
+    this.HasMoveRight = false;
     this.LoadTimeOut = LoadTimeOut;
     this.LoadFinishCallBack = undefined;
     this.LoadFailureCallBack = undefined;
@@ -1153,6 +1154,13 @@ class Engine {
           if (this.Ponder && this.PonderMiss) {
             this.PonderMiss = false;
           } else {
+            if (!this.HasMoveRight) {
+              console.warn(
+                `Engine ${this.Color} ID ${this.ID} claims multiple moves.`,
+              );
+              return;
+            }
+            this.HasMoveRight = false;
             let bestmoveline = Message.split(" ");
             if (bestmoveline[1] == "resign" || bestmoveline[2] == "resign") {
               if (this.IsAnalysisEngine) {
@@ -1933,6 +1941,7 @@ class Engine {
     if (!this.IsUsing) {
       return;
     }
+    this.HasMoveRight = true;
     this.IsThinking = true;
     this.RecordedMultiplePrincipalVariation = 0;
     let CurrentPlayerColor = CurrentPlayer.toUpperCase();

--- a/src/main.js
+++ b/src/main.js
@@ -464,6 +464,9 @@ function parseUCIMove(ucimove) {
   if (typeof ucimove != "string") {
     throw TypeError;
   }
+  if (ucimove == "0000") {
+    return ["", "", "", ""];
+  }
   let move = ucimove;
   let gatingmove = "";
   if (move.includes(",")) {
@@ -1384,8 +1387,11 @@ new Module().then((loadedModule) => {
           Math.min(...evaluationindex.slice(0, recordedmultipv)),
         );
       }
+      if (bestpv < 0) {
+        bestpv = 0;
+      }
       bestmove = parseUCIMove(textparselist[1]);
-      if (textparselist[3] != undefined) {
+      if (textparselist[3] != undefined && textparselist[3] != "0000") {
         ponder = parseUCIMove(textparselist[3]);
       }
       multipvrecord[bestpv][2] = bestmove;
@@ -1423,10 +1429,16 @@ new Module().then((loadedModule) => {
         Math.min(...evaluationindex.slice(0, recordedmultipv)),
       );
     }
+    if (bestpv < 0) {
+      bestpv = 0;
+    }
     console.log("Best PV:", bestpv + 1);
     if (multipvrecord[bestpv][0]) {
       let matemoves = multipvrecord[bestpv][1];
-      if (matemoves > 0) {
+      if (isNaN(matemoves) || matemoves == null) {
+        evaluationBar.style.width = "50%";
+        evalscore.innerText = "Mate in ❓";
+      } else if (matemoves > 0) {
         evaluationBar.style.width = "100%";
         evalscore.innerText = "Mate in " + matemoves.toString();
       } else if (matemoves < 0) {
@@ -1443,18 +1455,23 @@ new Module().then((loadedModule) => {
       }
     } else {
       evaluation = multipvrecord[bestpv][1];
-      if (evaluation > 0) {
-        evalscore.innerText = "+" + evaluation.toFixed(2).toString();
+      if (isNaN(evaluation) || evaluation == null) {
+        evalscore.innerText = "❓";
+        evaluationBar.style.width = "50%";
       } else {
-        evalscore.innerText = evaluation.toFixed(2);
-      }
-      if (evaluation < -9.8) {
-        evaluationBar.style.width = "1%";
-      } else if (evaluation > 9.8) {
-        evaluationBar.style.width = "99%";
-      } else {
-        evaluationBar.style.width =
-          parseInt((evaluation * 100 + 1000) / 20).toString() + "%";
+        if (evaluation > 0) {
+          evalscore.innerText = "+" + evaluation.toFixed(2).toString();
+        } else {
+          evalscore.innerText = evaluation.toFixed(2);
+        }
+        if (evaluation < -9.8) {
+          evaluationBar.style.width = "1%";
+        } else if (evaluation > 9.8) {
+          evaluationBar.style.width = "99%";
+        } else {
+          evaluationBar.style.width =
+            parseInt((evaluation * 100 + 1000) / 20).toString() + "%";
+        }
       }
     }
     let autoshapes = [];

--- a/src/main.js
+++ b/src/main.js
@@ -92,6 +92,7 @@ const haspiecechange = document.getElementById("haspiecechange");
 const buttonmakemove = document.getElementById("makemove");
 const buttonhighlightmove = document.getElementById("highlightmove");
 const searchresultinfo = document.getElementById("searchresultinfo");
+const dropdownNotationSystem = document.getElementById("sannotation");
 const soundMove = new Audio("assets/sound/thearst3rd/move.wav");
 const soundCapture = new Audio("assets/sound/thearst3rd/capture.wav");
 const soundCheck = new Audio("assets/sound/thearst3rd/check.wav");
@@ -848,6 +849,228 @@ function highlightMoveOnBoard(move) {
   chessground.setAutoShapes(autoshapes);
 }
 
+function getNotation(notation, variant, startfen, is960, ucimoves) {
+  if (
+    typeof notation != "string" ||
+    typeof variant != "string" ||
+    typeof startfen != "string" ||
+    typeof is960 != "boolean" ||
+    typeof ucimoves != "string"
+  ) {
+    throw TypeError();
+  }
+  if (ffish) {
+    if (window.fairyground) {
+      if (window.fairyground.BinaryEngineFeature) {
+        const fge = window.fairyground.BinaryEngineFeature;
+        const variants = ffish.variants().split(" ");
+        if (variants.includes(variant)) {
+          if (ffish.validateFen(startfen, variant, is960) >= 0) {
+            let tmpboard = new ffish.Board(variant, startfen, is960);
+            let moveslist = ucimoves.trim().split(/[ ]+/).reverse();
+            let result = "";
+            if (moveslist.length == 1 && moveslist[0] == "") {
+            } else {
+              while (moveslist.length > 0) {
+                if (!tmpboard.push(moveslist.pop())) {
+                  return null;
+                }
+              }
+            }
+            if (notation == "DEFAULT") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(ucimoves, ffish.Notation.DEFAULT);
+            } else if (notation == "SAN") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(ucimoves, ffish.Notation.SAN);
+            } else if (notation == "LAN") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(ucimoves, ffish.Notation.LAN);
+            } else if (notation == "SHOGI_HOSKING") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(
+                ucimoves,
+                ffish.Notation.SHOGI_HOSKING,
+              );
+            } else if (notation == "SHOGI_HODGES") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(
+                ucimoves,
+                ffish.Notation.SHOGI_HODGES,
+              );
+            } else if (notation == "SHOGI_HODGES_NUMBER") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(
+                ucimoves,
+                ffish.Notation.SHOGI_HODGES_NUMBER,
+              );
+            } else if (notation == "JANGGI") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(ucimoves, ffish.Notation.JANGGI);
+            } else if (notation == "XIANGQI_WXF") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(
+                ucimoves,
+                ffish.Notation.XIANGQI_WXF,
+              );
+            } else if (notation == "THAI_SAN") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(ucimoves, ffish.Notation.THAI_SAN);
+            } else if (notation == "THAI_LAN") {
+              tmpboard.setFen(startfen);
+              return tmpboard.variationSan(ucimoves, ffish.Notation.THAI_LAN);
+            } else if (notation == "FEN") {
+              return tmpboard.fen();
+            } else if (notation == "PGN") {
+              tmpboard.setFen(startfen);
+              const today = new Date();
+              const year = today.getFullYear();
+              const month = today.getMonth() + 1;
+              const day = today.getDate();
+              const hours = today.getHours();
+              const minutes = today.getMinutes();
+              const seconds = today.getSeconds();
+              let whitename = "";
+              let blackname = "";
+              if (playWhite.checked) {
+                if (fge.first_engine) {
+                  whitename = fge.first_engine.Name;
+                } else {
+                  whitename = "In browser Fairy-Stockfish";
+                }
+              } else {
+                whitename = "Human Player";
+              }
+              if (playBlack.checked) {
+                if (fge.second_engine) {
+                  blackname = fge.second_engine.Name;
+                } else {
+                  blackname = "In browser Fairy-Stockfish";
+                }
+              } else {
+                blackname = "Human Player";
+              }
+              result = `[Event "Fairy-Stockfish Playground match"]\n[Site "${window.location.host}"]\n[Date "${year.toString() + "." + month.toString() + "." + day.toString()}"]\n`;
+              result += `[Round "1"]\n[White "${whitename}"]\n[Black "${blackname}"]\n`;
+              result += `[FEN "${startfen}"]\n[Result "${tmpboard.result()}"]\n[Variant "${tmpboard.variant()}"]\n\n`;
+              result += tmpboard.variationSan(ucimoves, ffish.Notation.SAN);
+              return result;
+            } else if (notation == "EPD") {
+              const gamefen = tmpboard.fen().split(/[ ]+/);
+              result = `${gamefen[0]} ${gamefen[1]} ${gamefen[2]} ${gamefen[3]}`;
+              result += ` acd 0;`;
+              result += ` acn 0;`;
+              result += ` acs 0;`;
+              result += ` am 0000;`;
+              result += ` bm 0000;`;
+              result += ` ce 0.0;`;
+              result += ` dm 0;`;
+              result += ` draw_accept "null";`;
+              result += ` draw_claim "null";`;
+              result += ` draw_reject "null";`;
+              result += ` eco "null";`;
+              if (gamefen.length == 6) {
+                result += ` fmvn ${gamefen[5]};`;
+                result += ` hmvc ${gamefen[4]};`;
+              } else if (gamefen.length == 7) {
+                result += ` fmvn ${gamefen[6]};`;
+                result += ` hmvc ${gamefen[5]};`;
+              } else {
+                result += ` fmvn 0;`;
+                result += ` hmvc 0;`;
+              }
+              result += ` id "Fairy-Stockfish Playground match";`;
+              result += ` nic "null";`;
+              result += ` pm 0000;`;
+              result += ` pv 0;`;
+              result += ` rc 0;`;
+              result += ` resign "null";`;
+              result += ` sm 0000;`;
+              result += ` tcgs "null";`;
+              result += ` tcri "null";`;
+              result += ` tcsi "null";`;
+              result += ` v0 "null";`;
+              result += ` variant "${tmpboard.variant()}";`;
+              return result;
+            } else if (notation == "FEN+UCIMOVE") {
+              tmpboard.setFen(startfen);
+              return tmpboard.fen() + "|" + ucimoves;
+            } else if (notation == "FEN+USIMOVE") {
+              tmpboard.setFen(startfen);
+              let dimensions = getDimensions();
+              const convertedmoves = fge.convertUCImovestoUSImoves(
+                ucimoves,
+                dimensions.width,
+                dimensions.height,
+              );
+              if (convertedmoves != null) {
+                return tmpboard.fen() + "|" + convertedmoves;
+              } else {
+                return (
+                  tmpboard.fen() +
+                  "|(There are moves that cannot be displayed in USI moves, such as pawn promotion or seirawan gating)"
+                );
+              }
+            } else if (notation == "FEN+UCCIMOVE") {
+              tmpboard.setFen(startfen);
+              let dimensions = getDimensions();
+              const convertedmoves = fge.convertUCImovestoUCCImoves(
+                ucimoves,
+                dimensions.width,
+                dimensions.height,
+              );
+              if (convertedmoves != null) {
+                return tmpboard.fen() + "|" + convertedmoves;
+              } else {
+                return (
+                  tmpboard.fen() +
+                  "|(There are moves that cannot be displayed in UCCI moves, such as pawn promotion or seirawan gating)"
+                );
+              }
+            } else if (notation == "SFEN+USIMOVE") {
+              tmpboard.setFen(startfen);
+              let dimensions = getDimensions();
+              const convertedmoves = fge.convertUCImovestoUSImoves(
+                ucimoves,
+                dimensions.width,
+                dimensions.height,
+              );
+              if (convertedmoves != null) {
+                return (
+                  fge.ConvertFENtoSFEN(tmpboard.fen()) +
+                  "|" +
+                  fge.convertUCImovestoUSImoves(
+                    ucimoves,
+                    dimensions.width,
+                    dimensions.height,
+                  )
+                );
+              } else {
+                return (
+                  fge.ConvertFENtoSFEN(tmpboard.fen()) +
+                  "|(There are moves that cannot be displayed in USI moves, such as pawn promotion or seirawan gating)"
+                );
+              }
+            }
+          } else {
+            return "Illegal FEN";
+          }
+        } else {
+          return null;
+        }
+      } else {
+        throw Error(
+          "Namespace window.fairyground.BinaryEngineFeature does not exist",
+        );
+      }
+    } else {
+      throw Error("Namespace window.fairyground does not exist");
+    }
+  } else {
+    throw Error("ffish.js is not initialized!!!");
+  }
+}
+
 function getDimensions() {
   const fenBoard = board.fen().split(" ")[0];
   const ranks = fenBoard.split("/").length;
@@ -1318,7 +1541,11 @@ new Module().then((loadedModule) => {
       }
       multipvrecord[multipvid][2] = bestmove;
       multipvrecord[multipvid][3] = ponder;
-      multipvrecord[multipvid][4] = board.variationSan(
+      multipvrecord[multipvid][4] = getNotation(
+        dropdownNotationSystem[dropdownNotationSystem.selectedIndex].value,
+        board.variant(),
+        board.fen(),
+        false,
         textparselist.slice(textparselist.indexOf("pv") + 1).join(" "),
       );
       index = textparselist.indexOf("depth");
@@ -1865,6 +2092,12 @@ new Module().then((loadedModule) => {
       return;
     }
     highlightMoveOnBoard(move);
+  };
+
+  dropdownNotationSystem.onchange = function () {
+    if (labelPgn) {
+      labelPgn.innerText = getPgn(board);
+    }
   };
 
   updateChessground();
@@ -2662,35 +2895,47 @@ function afterMove(capture) {
 }
 
 function getPgn(board) {
-  let pgn = "";
-  const reversedMoves = [];
-  let moveStack = board.moveStack();
+  if (
+    dropdownNotationSystem[dropdownNotationSystem.selectedIndex].value == ""
+  ) {
+    let pgn = "";
+    const reversedMoves = [];
+    let moveStack = board.moveStack();
 
-  while (moveStack.length > 0) {
-    // TODO: improve this :/
-    reversedMoves.push(moveStack.split(" ").pop());
-    board.pop();
-    moveStack = board.moveStack();
-  }
-
-  if (!board.turn() && reversedMoves.length > 0) {
-    pgn += board.fullmoveNumber() + "... ";
-  }
-
-  while (reversedMoves.length > 0) {
-    const move = reversedMoves.pop();
-
-    if (board.turn()) {
-      pgn += board.fullmoveNumber() + ". ";
+    while (moveStack.length > 0) {
+      // TODO: improve this :/
+      reversedMoves.push(moveStack.split(" ").pop());
+      board.pop();
+      moveStack = board.moveStack();
     }
 
-    pgn += board.sanMove(move) + " ";
-    board.push(move);
-  }
+    if (!board.turn() && reversedMoves.length > 0) {
+      pgn += board.fullmoveNumber() + "... ";
+    }
 
-  const result = board.result(checkboxAdjudicate.checked);
-  if (result !== "*") pgn += result;
-  return pgn.trim();
+    while (reversedMoves.length > 0) {
+      const move = reversedMoves.pop();
+
+      if (board.turn()) {
+        pgn += board.fullmoveNumber() + ". ";
+      }
+
+      pgn += board.sanMove(move) + " ";
+      board.push(move);
+    }
+
+    const result = board.result(checkboxAdjudicate.checked);
+    if (result !== "*") pgn += result;
+    return pgn.trim();
+  } else {
+    return getNotation(
+      dropdownNotationSystem[dropdownNotationSystem.selectedIndex].value,
+      board.variant(),
+      textFen.value == "" ? ffish.startingFen(board.variant()) : textFen.value,
+      false,
+      textMoves.value,
+    );
+  }
 }
 
 function disableBoardMove() {

--- a/src/main.js
+++ b/src/main.js
@@ -11,6 +11,8 @@ const checkboxDests = document.getElementById("check-dests");
 const checkboxAdjudicate = document.getElementById("check-adjudicate");
 const textFen = document.getElementById("fen");
 const textMoves = document.getElementById("move");
+const buttonSetFen = document.getElementById("setpos");
+const buttonStop = document.getElementById("stop");
 const pSetFen = document.getElementById("set");
 const labelPgn = document.getElementById("label-pgn");
 const labelStm = document.getElementById("label-stm");
@@ -909,12 +911,6 @@ new Module().then((loadedModule) => {
     let play_white = playWhite.checked;
     let play_black = playBlack.checked;
     buttonCurrentPosition.click();
-    if (play_white) {
-      playWhite.click();
-    }
-    if (play_black) {
-      playBlack.click();
-    }
 
     updateChessground();
     initializeThemes.click();
@@ -973,6 +969,12 @@ new Module().then((loadedModule) => {
           continue;
         }
         if (!board.push(move)) {
+          buttonStop.click();
+          textMoves.value = textMoves.value
+            .trim()
+            .split(/[ ]+/)
+            .slice(0, -1)
+            .join(" ");
           window.alert(`Invalid move: ${move}`);
         }
       }
@@ -1119,7 +1121,7 @@ new Module().then((loadedModule) => {
     if (dropdownPositionVariantType.value == "(default)") {
       textFen.value = "";
       textMoves.value = "";
-      pSetFen.click();
+      buttonSetFen.click();
     }
     UpdateVariantsPositionNameDropdown();
     positionInformation.innerHTML = "";
@@ -1870,6 +1872,12 @@ function updateChessBoardToPosition(fen, movelist, enablemove) {
         continue;
       }
       if (!board.push(move)) {
+        buttonStop.click();
+        textMoves.value = textMoves.value
+          .trim()
+          .split(/[ ]+/)
+          .slice(0, -1)
+          .join(" ");
         window.alert(`Invalid move: ${move}`);
       }
     }

--- a/src/main.js
+++ b/src/main.js
@@ -1586,7 +1586,7 @@ new Module().then((loadedModule) => {
             showevalnum = multipvrecord[k][1].toFixed(2).toString();
           }
         }
-        pvinfostr += `Principal Variation ${k + 1}: (Depth: Average ${multipvrecord[k][5] > -1 ? multipvrecord[k][5] : "❓"} Max ${multipvrecord[k][6] > -1 ? multipvrecord[k][6] : "❓"}) ${showevalnum} → ${multipvrecord[k][4]}\n████████████████████\n`;
+        pvinfostr += `Principal Variation ${k + 1}: (Depth: Average ${multipvrecord[k][5] > -1 ? multipvrecord[k][5] : "❓"} Max ${multipvrecord[k][6] > -1 ? multipvrecord[k][6] : "❓"}) ${showevalnum} → ${multipvrecord[k][4]}\n\n`;
         depthlist.push(multipvrecord[k][5]);
         seldepthlist.push(multipvrecord[k][6]);
       }

--- a/src/main.js
+++ b/src/main.js
@@ -849,13 +849,13 @@ function highlightMoveOnBoard(move) {
   chessground.setAutoShapes(autoshapes);
 }
 
-function getNotation(notation, variant, startfen, is960, ucimoves) {
+function getNotation(notation, variant, startfen, is960, ucimovestr) {
   if (
     typeof notation != "string" ||
     typeof variant != "string" ||
     typeof startfen != "string" ||
     typeof is960 != "boolean" ||
-    typeof ucimoves != "string"
+    typeof ucimovestr != "string"
   ) {
     throw TypeError();
   }
@@ -864,10 +864,11 @@ function getNotation(notation, variant, startfen, is960, ucimoves) {
       if (window.fairyground.BinaryEngineFeature) {
         const fge = window.fairyground.BinaryEngineFeature;
         const variants = ffish.variants().split(" ");
+        let ucimoves = ucimovestr.trim();
         if (variants.includes(variant)) {
           if (ffish.validateFen(startfen, variant, is960) >= 0) {
             let tmpboard = new ffish.Board(variant, startfen, is960);
-            let moveslist = ucimoves.trim().split(/[ ]+/).reverse();
+            let moveslist = ucimoves.split(/[ ]+/).reverse();
             let result = "";
             if (moveslist.length == 1 && moveslist[0] == "") {
             } else {
@@ -922,6 +923,7 @@ function getNotation(notation, variant, startfen, is960, ucimoves) {
             } else if (notation == "FEN") {
               return tmpboard.fen();
             } else if (notation == "PGN") {
+              const gameresult = tmpboard.result();
               tmpboard.setFen(startfen);
               const today = new Date();
               const year = today.getFullYear();
@@ -952,7 +954,7 @@ function getNotation(notation, variant, startfen, is960, ucimoves) {
               }
               result = `[Event "Fairy-Stockfish Playground match"]\n[Site "${window.location.host}"]\n[Date "${year.toString() + "." + month.toString() + "." + day.toString()}"]\n`;
               result += `[Round "1"]\n[White "${whitename}"]\n[Black "${blackname}"]\n`;
-              result += `[FEN "${startfen}"]\n[Result "${tmpboard.result()}"]\n[Variant "${tmpboard.variant()}"]\n\n`;
+              result += `[FEN "${startfen}"]\n[Result "${gameresult}"]\n[Variant "${tmpboard.variant()}"]\n\n`;
               result += tmpboard.variationSan(ucimoves, ffish.Notation.SAN);
               return result;
             } else if (notation == "EPD") {

--- a/src/main.js
+++ b/src/main.js
@@ -464,8 +464,8 @@ function parseUCIMove(ucimove) {
   if (typeof ucimove != "string") {
     throw TypeError;
   }
-  if (ucimove == "0000") {
-    return ["", "", "", ""];
+  if (ucimove == "0000" || ucimove == "") {
+    return [undefined, undefined, undefined, undefined];
   }
   let move = ucimove;
   let gatingmove = "";
@@ -1268,7 +1268,7 @@ new Module().then((loadedModule) => {
       return;
     }
     if (text.includes(" multipv ")) {
-      let textparselist = text.split(" ");
+      let textparselist = text.split(/[ ]+/);
       multipvid =
         parseInt(textparselist[textparselist.indexOf("multipv") + 1]) - 1;
       if (multipvid + 1 > recordedmultipv) {
@@ -1278,7 +1278,7 @@ new Module().then((loadedModule) => {
     let bestmove = [];
     let ponder = [];
     if (text.includes(" score ") && text.includes(" pv ")) {
-      let textparselist = text.split(" ");
+      let textparselist = text.split(/[ ]+/);
       let evaltext = textparselist.at(textparselist.indexOf("score") + 1);
       if (evaltext == "mate") {
         let matenum = parseInt(

--- a/src/main.js
+++ b/src/main.js
@@ -859,6 +859,9 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
   ) {
     throw TypeError();
   }
+  if (notation == "") {
+    return "(Missing notaion system, please select one in the dropdown...)";
+  }
   if (ffish) {
     if (window.fairyground) {
       if (window.fairyground.BinaryEngineFeature) {
@@ -1583,7 +1586,7 @@ new Module().then((loadedModule) => {
             showevalnum = multipvrecord[k][1].toFixed(2).toString();
           }
         }
-        pvinfostr += `Principal Variation ${k + 1}: (Depth: Average ${multipvrecord[k][5] > -1 ? multipvrecord[k][5] : "❓"} Max ${multipvrecord[k][6] > -1 ? multipvrecord[k][6] : "❓"}) ${showevalnum} → ${multipvrecord[k][4]}\n`;
+        pvinfostr += `Principal Variation ${k + 1}: (Depth: Average ${multipvrecord[k][5] > -1 ? multipvrecord[k][5] : "❓"} Max ${multipvrecord[k][6] > -1 ? multipvrecord[k][6] : "❓"}) ${showevalnum} → ${multipvrecord[k][4]}\n████████████████████\n`;
         depthlist.push(multipvrecord[k][5]);
         seldepthlist.push(multipvrecord[k][6]);
       }

--- a/src/main.js
+++ b/src/main.js
@@ -1319,6 +1319,7 @@ new Module().then((loadedModule) => {
     }
     if (validateFEN(FEN, false)) {
       textFen.value = FEN;
+      textMoves.value = "";
       copySetFEN.click();
     } else {
       window.alert("Failed to apply the position. There are errors in it.");

--- a/src/server.js
+++ b/src/server.js
@@ -554,19 +554,3 @@ const interval = setInterval(function ping() {
     ws.ping(noop);
   });
 }, 30000);
-
-function openDefaultBrowser(url) {
-  var exec = require('child_process').exec;
-  switch (process.platform) {
-    case "darwin":
-      exec('open ' + url);
-      break;
-    case "win32":
-      exec('start ' + url);
-      break;
-    default:
-      exec('xdg-open ' + url);
-  }
-}
-
-openDefaultBrowser(`http://localhost:${port}`);

--- a/src/server.js
+++ b/src/server.js
@@ -61,7 +61,7 @@ var ClientEngines = new Map();
 var ConnectingClients = new Set();
 var ConnectedClients = new Set();
 const PathLevelSeperatorMatcher = new RegExp("\\\\|/", "");
-const MessageSplitter = new RegExp("(?<!\\\\)\\|", "");
+const MessageSplitter = new RegExp("\x10", "");
 
 function GetWorkingDirectoryFromExcutablePath(path) {
   if (typeof path != "string") {
@@ -145,15 +145,15 @@ class Engine {
     if (WebSocketConnection.readyState != WebSocketConnection.OPEN) {
       throw Error("WebSocket connection error");
     }
-    this.ID = ID.replace("|", "\\|");
-    this.Command = Command.replace("|", "\\|");
-    this.WorkingDirectory = WorkingDirectory.replace("|", "\\|");
+    this.ID = ID;
+    this.Command = Command;
+    this.WorkingDirectory = WorkingDirectory;
     if (WorkingDirectory == "") {
       this.WorkingDirectory = GetWorkingDirectoryFromExcutablePath(Command);
     }
-    this.Protocol = Protocol.replace("|", "\\|");
+    this.Protocol = Protocol;
     this.Options = Options;
-    this.Color = Color.replace("|", "\\|");
+    this.Color = Color;
     this.IsLoading = false;
     this.IsLoaded = false;
     this.Process = null;
@@ -258,7 +258,7 @@ class Engine {
         err,
       );
       this.WebSocketConnection.send(
-        `ERROR|LOAD_ENGINE|${this.ID}|${this.Color}`,
+        `ERROR\x10LOAD_ENGINE\x10${this.ID}\x10${this.Color}`,
       );
       if (typeof this.LoadFailureCallBack == "function") {
         this.LoadFailureCallBack();
@@ -275,7 +275,7 @@ class Engine {
             `[WebSocket Server] Engine ${this.Color} (ID: ${this.ID}) load timed out.`,
           );
           this.WebSocketConnection.send(
-            `ERROR|ENGINE_TIMEOUT|${this.ID}|${this.Color}`,
+            `ERROR\x10ENGINE_TIMEOUT\x10${this.ID}\x10${this.Color}`,
           );
         } else {
           console.error(
@@ -283,7 +283,7 @@ class Engine {
             code,
           );
           this.WebSocketConnection.send(
-            `ERROR|LOAD_ENGINE|${this.ID}|${this.Color}`,
+            `ERROR\x10LOAD_ENGINE\x10${this.ID}\x10${this.Color}`,
           );
         }
         this.Status = "";
@@ -295,12 +295,12 @@ class Engine {
     });
     this.Process.stdout.on("data", (data) => {
       this.WebSocketConnection.send(
-        `ENGINE_STDOUT|${this.ID}|${this.Color}|${data}`,
+        `ENGINE_STDOUT\x10${this.ID}\x10${this.Color}\x10${data}`,
       );
     });
     this.Process.stderr.on("data", (data) => {
       this.WebSocketConnection.send(
-        `ENGINE_STDERR|${this.ID}|${this.Color}|${data}`,
+        `ENGINE_STDERR\x10${this.ID}\x10${this.Color}\x10${data}`,
       );
     });
     console.log(
@@ -355,7 +355,7 @@ class Engine {
     if (msg[0] == "POST_MSG") {
       if (msg.length != 4) {
         console.warn(
-          "[WebSocket Server] Received bad data from client. Syntax: POST_MSG|<ID>|<Color>|<info...>.",
+          "[WebSocket Server] Received bad data from client. Syntax: POST_MSG\x10<ID>\x10<Color>\x10<info...>.",
         );
         return;
       }
@@ -365,7 +365,7 @@ class Engine {
     } else if (msg[0] == "ENGINE_READY") {
       if (msg.length != 3) {
         console.warn(
-          "[WebSocket Server] Received bad data from client. Syntax: ENGINE_READY|<ID>|<Color>.",
+          "[WebSocket Server] Received bad data from client. Syntax: ENGINE_READY\x10<ID>\x10<Color>.",
         );
         return;
       }
@@ -379,7 +379,9 @@ class Engine {
     ) {
       if (typeof msg[3] == "string") {
         this.ID = msg[3];
-        this.WebSocketConnection.send(`ID_CHANGED|${this.ID}|${this.Color}`);
+        this.WebSocketConnection.send(
+          `ID_CHANGED\x10${this.ID}\x10${this.Color}`,
+        );
       }
     }
   }
@@ -390,7 +392,7 @@ wss.on("connection", (ws, req) => {
   ws.isAlive = true;
   ws.on("pong", heartbeat);
   ws.on("message", (message) => {
-    let msg = message.toString().split("|");
+    let msg = message.toString().split(MessageSplitter);
     if (msg[0] == "CONNECT") {
       if (ConnectingClients.has(ws) || ConnectedClients.has(ws)) {
         console.warn(
@@ -429,7 +431,7 @@ wss.on("connection", (ws, req) => {
     if (msg[0] == "LOAD_ENGINE") {
       if (msg.length != 7) {
         console.warn(
-          "[WebSocket Server] Received bad data from client. Syntax: LOAD_ENGINE|<ID>|<Color>|<Protocol>|<Command>|<WorkingDirectory>|<LoadTimeOut>.",
+          "[WebSocket Server] Received bad data from client. Syntax: LOAD_ENGINE\x10<ID>\x10<Color>\x10<Protocol>\x10<Command>\x10<WorkingDirectory>\x10<LoadTimeOut>.",
         );
         return;
       }
@@ -474,7 +476,7 @@ wss.on("connection", (ws, req) => {
     } else if (msg[0] == "EXIT_ENGINE") {
       if (msg.length != 3) {
         console.warn(
-          "[WebSocket Server] Received bad data from client. Syntax: EXIT_ENGINE|<ID>|<Color>.",
+          "[WebSocket Server] Received bad data from client. Syntax: EXIT_ENGINE\x10<ID>\x10<Color>.",
         );
         return;
       }
@@ -496,11 +498,11 @@ wss.on("connection", (ws, req) => {
       }
     } else if (msg[0] == "GET_ENGINE_LIST") {
       let content = ReadFile("./EngineList.txt");
-      ws.send(`ENGINE_LIST|${content}`);
+      ws.send(`ENGINE_LIST\x10${content}`);
     } else if (msg[0] == "SAVE_ENGINE_LIST") {
       if (msg.length != 2) {
         console.warn(
-          "[WebSocket Server] Received bad data from client. Syntax: SAVE_ENGINE_LIST|<EngineListText>.",
+          "[WebSocket Server] Received bad data from client. Syntax: SAVE_ENGINE_LIST\x10<EngineListText>.",
         );
         return;
       }
@@ -509,7 +511,7 @@ wss.on("connection", (ws, req) => {
     } else if (msg[0] == "CHANGE_ID") {
       if (msg.length != 4) {
         console.warn(
-          "[WebSocket Server] Received bad data from client. Syntax: CHANGE_ID|<OldID>|<Color>|<NewID>.",
+          "[WebSocket Server] Received bad data from client. Syntax: CHANGE_ID\x10<OldID>\x10<Color>\x10<NewID>.",
         );
         return;
       }


### PR DESCRIPTION
# Structure Changes
1. Now advanced.html will load BinaryEngineFeature.js at ./public/lib. All major functions are provided in this JavaScript file. BinaryEngineFeature.js itself does not contain GUI logic, all functions and classes are used in the <script> area of advanced.html.
2. A server.js will be created after `npm run build` or `npm run buildwithcmd`. This JavaScript file is intended to be executed by node runtime. It provides a HTTP server which deals with the response headers, having the same function with "serve". Moreover, it provides a WebSocket server that enables engine and browser communicate with each other.
3. Hosting this page online is still possible, as this page can work without a backend. In this case, binary engine loading feature will be disabled and the engine management section will be hidden.
4. There are no big changes to index.html (Play against Fairy-Stockfish page), and the engine management section is visible on this page. However configuring it can be complicated to some extent. It remains to be seen whether it is suitable to show it on this page.

# Functions
1. Load engines with UCI / USI / UCCI / UCI: Cyclone Protocols. XBoard/WinBoard protocol is not supported.
2. Supports Ponder (Can be set differently for 2 sides).
3. Analysis result display, only applies to analysis engine in analysis mode.
4. Load/Save added engines.

# Usage Logic
1. When the binary engine is not loaded, in browser FSF will be used.
2. When the binary engine does not support current variant, in browser FSF will be used.
3. When not in advanced time control, engines are controlled by Depth, Move Time and Nodes. Otherwise they are controlled by the timing system.
4. If the engine has option named "UCI_Variant", "USI_Variant" or "UCCI_Variant" with combo box type , then the GUI consider this engine supports variant system. Otherwise the supported variants for the engine are set to default values. (UCI: "", "chess", "fischerrandom";  USI: "shogi";  UCCI/UCI: Cyclone: "xiangqi")
5. To enable engine pondering, go to Engine Management >> Change Options >> Edit Options... >> Check "Ponder". Then the GUI will enable pondering for this engine. In browser FSF does not support pondering as in some cases it needs to play on both sides.

# Other improvements
Fixed some event handler bugs. (e.g. the position is set for multiple times after clicking "set" button)

# Potential problems
1. When a engine only supports UCI: Cyclone, while the user selects UCI as engine protocol, it will work at first, but encounter problems when in the games as the notations are different from UCI (UCI starts with rank 1 while UCI: Cyclone starts with rank 0). Currently the GUI cannot detect it.
2. Potential event handler issues. I've tested most functions and they seemed to be well, but there can be some rare cases that can cause problems.
3. Some engines will always send "bestmove" after "stop", this can cause invalid moves if "bestmove" is received after "go" due to communication delay. Currently the GUI cannot handle this condition and show a "Invalid move" dialog.
4. The reason why the server must be run on local host is that if the host is not local host, the response headers cannot be set correctly, causing FSF WASM cannot get loaded and crashing the page. To solve this, a HTTPS connection is required which requires a certificate. Meanwhile, the WS (WebSocket) should also be changed to WSS and needs a certificate. Another workaround may be port forwarding, which can make the website pretend to be a local host website and bypass these restrictions.
5. Currently most of the program is process-oriented due to previously written code, which may cause difficulties on maintenance. Probably a change on the framework to convert the code into object-oriented style would be better.

# Test Environment
Tested on Windows 10, browsers contain FireFox and Edge. Engines include: Stockfish, Fairy-Stockfish, Komodo Dragon, Leela Chess 0, YaneuraOu (Shogi, USI), PikaFish (Xiangqi, UCI: Cyclone), CrazyAra (Crazyhouse, UCI), LesserKai (Shogi, USI).