### PR TITLE
Add Invisible (Blindfold) theme and restore graphics of Duck Chess

### DIFF
--- a/public/assets/images/wallsquare/noentry.svg
+++ b/public/assets/images/wallsquare/noentry.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="100"
+   height="100"
+   viewBox="0 0 26.458333 26.458333"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   sodipodi:docname="noentry.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="4.12225"
+     inkscape:cx="51.670811"
+     inkscape:cy="55.673479"
+     inkscape:window-width="1920"
+     inkscape:window-height="1001"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1001">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.25914633"
+         id="stop997" />
+      <stop
+         style="stop-color:#c8c8c8;stop-opacity:1;"
+         offset="1"
+         id="stop999" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient979">
+      <stop
+         style="stop-color:#ff0000;stop-opacity:1;"
+         offset="0.34451219"
+         id="stop975" />
+      <stop
+         style="stop-color:#be0000;stop-opacity:1;"
+         offset="1"
+         id="stop977" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient979"
+       id="linearGradient981"
+       x1="2.1308762"
+       y1="13.229166"
+       x2="24.327456"
+       y2="13.229166"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1001"
+       id="linearGradient1005"
+       x1="6.7161622"
+       y1="13.229167"
+       x2="19.74217"
+       y2="13.229167"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:label="图层 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:url(#linearGradient981);stroke:#000000;stroke-width:1.32291667;stroke-linecap:round;stroke-opacity:1;stroke-dasharray:none;fill-opacity:1"
+       id="path234"
+       cx="13.229166"
+       cy="13.229166"
+       r="10.436831" />
+    <rect
+       style="fill:url(#linearGradient1005);stroke:#000000;stroke-width:0;stroke-linecap:round;fill-opacity:1;stroke-opacity:1;stroke-dasharray:none"
+       id="rect342"
+       width="13.026008"
+       height="2.4426744"
+       x="6.7161627"
+       y="12.00783" />
+  </g>
+</svg>

--- a/public/assets/theme-piece-blindfold.css
+++ b/public/assets/theme-piece-blindfold.css
@@ -1,0 +1,3 @@
+.blindfold .cg-wrap piece._-piece {
+  background-image: url('images/wallsquare/noentry.svg');
+}

--- a/public/themenames.txt
+++ b/public/themenames.txt
@@ -9,6 +9,7 @@ lettertiles|Letter Tiles
 letters|FEN Style Letters
 meridaletters|Merida Letters
 cburnettletters|Cburnett Letters
+blindfold|Invisible (Blindfold)
 userdefined|User Defined Graphics
 
 blueboard|Blue

--- a/public/themes.txt
+++ b/public/themes.txt
@@ -72,7 +72,7 @@
 #https://github.com/ianfab/fairyground/issues
 
 
-*|meridaletters,cburnettletters,lettertiles,letters,userdefined|
+*|meridaletters,cburnettletters,lettertiles,letters,blindfold,userdefined|
 |merida,cburnett|blueboard,greenboard,brownboard,purpleboard,cobaltboard
 
 seirawan|seirawan|

--- a/public/themes.txt
+++ b/public/themes.txt
@@ -77,6 +77,7 @@
 
 seirawan|seirawan|
 shouse|@seirawan|
+duck|duck|
 
 spartan|spartan|
 empire|empire|


### PR DESCRIPTION
After this change:
1. Added Invisible (Blindfold) theme. Now users can play blindfold.
2. Restore accidentally deleted graphics declaration in themes.txt during previous changes.

Does not conflict with #73 .