### PR TITLE
Change color for purple board

### DIFF
--- a/public/assets/images/board/purple/purple10x1.svg
+++ b/public/assets/images/board/purple/purple10x1.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 1000 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#000000">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">

--- a/public/assets/images/board/purple/purple10x1.svg
+++ b/public/assets/images/board/purple/purple10x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 1000 100">
 <g id="brown-board">
-<g id="Light" fill="#000000">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x10.svg
+++ b/public/assets/images/board/purple/purple10x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1000 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x2.svg
+++ b/public/assets/images/board/purple/purple10x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 1000 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x3.svg
+++ b/public/assets/images/board/purple/purple10x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 1000 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x4.svg
+++ b/public/assets/images/board/purple/purple10x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 1000 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x5.svg
+++ b/public/assets/images/board/purple/purple10x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 1000 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x6.svg
+++ b/public/assets/images/board/purple/purple10x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 1000 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x7.svg
+++ b/public/assets/images/board/purple/purple10x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 1000 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x8.svg
+++ b/public/assets/images/board/purple/purple10x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 1000 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple10x9.svg
+++ b/public/assets/images/board/purple/purple10x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 1000 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x1.svg
+++ b/public/assets/images/board/purple/purple11x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 1100 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x10.svg
+++ b/public/assets/images/board/purple/purple11x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1100 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x2.svg
+++ b/public/assets/images/board/purple/purple11x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 1100 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x3.svg
+++ b/public/assets/images/board/purple/purple11x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 1100 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x4.svg
+++ b/public/assets/images/board/purple/purple11x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 1100 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x5.svg
+++ b/public/assets/images/board/purple/purple11x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 1100 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x6.svg
+++ b/public/assets/images/board/purple/purple11x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 1100 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x7.svg
+++ b/public/assets/images/board/purple/purple11x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 1100 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x8.svg
+++ b/public/assets/images/board/purple/purple11x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 1100 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple11x9.svg
+++ b/public/assets/images/board/purple/purple11x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 1100 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x1.svg
+++ b/public/assets/images/board/purple/purple12x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 1200 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x10.svg
+++ b/public/assets/images/board/purple/purple12x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1200 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x2.svg
+++ b/public/assets/images/board/purple/purple12x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 1200 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x3.svg
+++ b/public/assets/images/board/purple/purple12x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 1200 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x4.svg
+++ b/public/assets/images/board/purple/purple12x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 1200 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x5.svg
+++ b/public/assets/images/board/purple/purple12x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 1200 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x6.svg
+++ b/public/assets/images/board/purple/purple12x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 1200 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x7.svg
+++ b/public/assets/images/board/purple/purple12x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 1200 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x8.svg
+++ b/public/assets/images/board/purple/purple12x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 1200 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple12x9.svg
+++ b/public/assets/images/board/purple/purple12x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 1200 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x1.svg
+++ b/public/assets/images/board/purple/purple1x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 100 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x10.svg
+++ b/public/assets/images/board/purple/purple1x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x2.svg
+++ b/public/assets/images/board/purple/purple1x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 100 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x3.svg
+++ b/public/assets/images/board/purple/purple1x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 100 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x4.svg
+++ b/public/assets/images/board/purple/purple1x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 100 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x5.svg
+++ b/public/assets/images/board/purple/purple1x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 100 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x6.svg
+++ b/public/assets/images/board/purple/purple1x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 100 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x7.svg
+++ b/public/assets/images/board/purple/purple1x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 100 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x8.svg
+++ b/public/assets/images/board/purple/purple1x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 100 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple1x9.svg
+++ b/public/assets/images/board/purple/purple1x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 100 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x1.svg
+++ b/public/assets/images/board/purple/purple2x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 200 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x10.svg
+++ b/public/assets/images/board/purple/purple2x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 200 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x2.svg
+++ b/public/assets/images/board/purple/purple2x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 200 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x3.svg
+++ b/public/assets/images/board/purple/purple2x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 200 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x4.svg
+++ b/public/assets/images/board/purple/purple2x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 200 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x5.svg
+++ b/public/assets/images/board/purple/purple2x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 200 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x6.svg
+++ b/public/assets/images/board/purple/purple2x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 200 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x7.svg
+++ b/public/assets/images/board/purple/purple2x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 200 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x8.svg
+++ b/public/assets/images/board/purple/purple2x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 200 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple2x9.svg
+++ b/public/assets/images/board/purple/purple2x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 200 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x1.svg
+++ b/public/assets/images/board/purple/purple3x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 300 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x10.svg
+++ b/public/assets/images/board/purple/purple3x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 300 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x2.svg
+++ b/public/assets/images/board/purple/purple3x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 300 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x3.svg
+++ b/public/assets/images/board/purple/purple3x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 300 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x4.svg
+++ b/public/assets/images/board/purple/purple3x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 300 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x5.svg
+++ b/public/assets/images/board/purple/purple3x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 300 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x6.svg
+++ b/public/assets/images/board/purple/purple3x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 300 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x7.svg
+++ b/public/assets/images/board/purple/purple3x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 300 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x8.svg
+++ b/public/assets/images/board/purple/purple3x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 300 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple3x9.svg
+++ b/public/assets/images/board/purple/purple3x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 300 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x1.svg
+++ b/public/assets/images/board/purple/purple4x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 400 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x10.svg
+++ b/public/assets/images/board/purple/purple4x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 400 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x2.svg
+++ b/public/assets/images/board/purple/purple4x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 400 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x3.svg
+++ b/public/assets/images/board/purple/purple4x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 400 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x4.svg
+++ b/public/assets/images/board/purple/purple4x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 400 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x5.svg
+++ b/public/assets/images/board/purple/purple4x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 400 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x6.svg
+++ b/public/assets/images/board/purple/purple4x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 400 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x7.svg
+++ b/public/assets/images/board/purple/purple4x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 400 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x8.svg
+++ b/public/assets/images/board/purple/purple4x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 400 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple4x9.svg
+++ b/public/assets/images/board/purple/purple4x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 400 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x1.svg
+++ b/public/assets/images/board/purple/purple5x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 500 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x10.svg
+++ b/public/assets/images/board/purple/purple5x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 500 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x2.svg
+++ b/public/assets/images/board/purple/purple5x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 500 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x3.svg
+++ b/public/assets/images/board/purple/purple5x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 500 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x4.svg
+++ b/public/assets/images/board/purple/purple5x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 500 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x5.svg
+++ b/public/assets/images/board/purple/purple5x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 500 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x6.svg
+++ b/public/assets/images/board/purple/purple5x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 500 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x7.svg
+++ b/public/assets/images/board/purple/purple5x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 500 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x8.svg
+++ b/public/assets/images/board/purple/purple5x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 500 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple5x9.svg
+++ b/public/assets/images/board/purple/purple5x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 500 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x1.svg
+++ b/public/assets/images/board/purple/purple6x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 600 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x10.svg
+++ b/public/assets/images/board/purple/purple6x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 600 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x2.svg
+++ b/public/assets/images/board/purple/purple6x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 600 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x3.svg
+++ b/public/assets/images/board/purple/purple6x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 600 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x4.svg
+++ b/public/assets/images/board/purple/purple6x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 600 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x5.svg
+++ b/public/assets/images/board/purple/purple6x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 600 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x6.svg
+++ b/public/assets/images/board/purple/purple6x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 600 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x7.svg
+++ b/public/assets/images/board/purple/purple6x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 600 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x8.svg
+++ b/public/assets/images/board/purple/purple6x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 600 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple6x9.svg
+++ b/public/assets/images/board/purple/purple6x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 600 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x1.svg
+++ b/public/assets/images/board/purple/purple7x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 700 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x10.svg
+++ b/public/assets/images/board/purple/purple7x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 700 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x2.svg
+++ b/public/assets/images/board/purple/purple7x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 700 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x3.svg
+++ b/public/assets/images/board/purple/purple7x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 700 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x4.svg
+++ b/public/assets/images/board/purple/purple7x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 700 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x5.svg
+++ b/public/assets/images/board/purple/purple7x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 700 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x6.svg
+++ b/public/assets/images/board/purple/purple7x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 700 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x7.svg
+++ b/public/assets/images/board/purple/purple7x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 700 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x8.svg
+++ b/public/assets/images/board/purple/purple7x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 700 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple7x9.svg
+++ b/public/assets/images/board/purple/purple7x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 700 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x1.svg
+++ b/public/assets/images/board/purple/purple8x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 800 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x10.svg
+++ b/public/assets/images/board/purple/purple8x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 800 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x2.svg
+++ b/public/assets/images/board/purple/purple8x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 800 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x3.svg
+++ b/public/assets/images/board/purple/purple8x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 800 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x4.svg
+++ b/public/assets/images/board/purple/purple8x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 800 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x5.svg
+++ b/public/assets/images/board/purple/purple8x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 800 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x6.svg
+++ b/public/assets/images/board/purple/purple8x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 800 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x7.svg
+++ b/public/assets/images/board/purple/purple8x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 800 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x8.svg
+++ b/public/assets/images/board/purple/purple8x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 800 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple8x9.svg
+++ b/public/assets/images/board/purple/purple8x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 800 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x1.svg
+++ b/public/assets/images/board/purple/purple9x1.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 900 900 100">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x10.svg
+++ b/public/assets/images/board/purple/purple9x10.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 900 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x2.svg
+++ b/public/assets/images/board/purple/purple9x2.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 800 900 200">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x3.svg
+++ b/public/assets/images/board/purple/purple9x3.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 700 900 300">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x4.svg
+++ b/public/assets/images/board/purple/purple9x4.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 600 900 400">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x5.svg
+++ b/public/assets/images/board/purple/purple9x5.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 500 900 500">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x6.svg
+++ b/public/assets/images/board/purple/purple9x6.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 400 900 600">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x7.svg
+++ b/public/assets/images/board/purple/purple9x7.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 300 900 700">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x8.svg
+++ b/public/assets/images/board/purple/purple9x8.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 200 900 800">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple9x9.svg
+++ b/public/assets/images/board/purple/purple9x9.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 100 900 900">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">

--- a/public/assets/images/board/purple/purple_base.svg
+++ b/public/assets/images/board/purple/purple_base.svg
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1200 1000">
 <g id="brown-board">
-<g id="Light" fill="#9f90b0">
+<g id="Light" fill="#eadfed">
 <rect width="1200" height="1000"/>
 </g>
 <g id="Frame" fill="none">
 <rect width="1200" height="1000"/>
 </g>
-<g id="Dark" fill="#7d4a8d">
+<g id="Dark" fill="#a781b1">
 <g id="raz">
 <g id="dva">
 <g id="tri">


### PR DESCRIPTION
Currently the purple board color is taken from PyChess's purple color style, which looks dark and sometimes it's hard to recognize some dark pieces.
After this change, the color style is changed to ffish-test's board color, which is brighter and has higher contrast. In my opinion this would look better, and match Blue, Green and Brown color style.

Before:
![image](https://github.com/ianfab/fairyground/assets/47345902/a0de7350-834c-4225-b65f-93d0a78d0eb3)

After:
![image](https://github.com/ianfab/fairyground/assets/47345902/b03730ca-e4c9-4c63-8472-614ecffc2c00)
