### PR TITLE
Null Move & WallOrMove Support & Fixes

### DIFF
--- a/public/advanced.html
+++ b/public/advanced.html
@@ -4941,6 +4941,7 @@
               "Click-click move",
             ),
             m("button#passmove", { disabled: !is_ready }, "🔄Pass This Turn"),
+            m("button#placewall", { disabled: !is_ready }, "🅿️Place A Wall"),
             m(
               "label#label-showmovediv",
               m("input[type=checkbox]#showmovediv", {

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -4963,6 +4963,17 @@
               },
               "[?]",
             ),
+            m(
+              "span",
+              {
+                style: "cursor: pointer; margin-left: 5px;",
+                onclick: () =>
+                  window.alert(
+                    "A null move is considered as a move that have the same original square and destination square. Double click a square (No matter whether it's empty or not) will make a null move on that square.\nNote:\n1. In most cases passing a turn is equivalent to making a null move on the king.\n2. In Atlantis variant, placing a wall without moving any piece requires to make a null move on the most bottom then the most left piece of your color.\n3. Click <show moves dialog> to see all legal moves if you are not sure how to make a move.",
+                  ),
+              },
+              "[How to make null moves?]",
+            ),
           ]),
           m("div#boardsetupsettings", { hidden: !board_setup_mode }, [
             m("p", "Board Setup:"),

--- a/release_make/package.json
+++ b/release_make/package.json
@@ -9,7 +9,8 @@
   "author": "",
   "license": "GPL-3.0-or-later",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "ws": "^8.16.0"
   },
   "bin": "./index.js"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -73,6 +73,7 @@ const clickClickMove = document.getElementById("clickclickmove");
 const positionVariantTxt = document.getElementById("posvariant-txt");
 const quickPromotionPiece = document.getElementById("dropdown-quickpromotion");
 const buttonPassMove = document.getElementById("passmove");
+const buttonPlaceWall = document.getElementById("placewall");
 const engineOutput = document.getElementById("engineoutputline");
 const isAnalysis = document.getElementById("analysis");
 const evaluationBar = document.getElementById("evalbarprogress");
@@ -1592,6 +1593,60 @@ new Module().then((loadedModule) => {
       return;
     }
     afterChessgroundMove(passmove.orig, passmove.dest, {
+      premove: false,
+      ctrlKey: false,
+      holdTime: 0,
+      captured: {
+        role: null,
+        color: null,
+        promoted: false,
+      },
+      predrop: false,
+    });
+  };
+
+  buttonPlaceWall.onclick = function () {
+    if (
+      chessground.state.movable.color == "both" ||
+      chessground.state.movable.color == undefined
+    ) {
+      return;
+    }
+    const moves = board
+      .legalMoves()
+      .trim()
+      .split(" ")
+      .filter((element) => {
+        if (
+          typeof element != "string" ||
+          element.length < 4 ||
+          !element.includes(",")
+        ) {
+          return false;
+        }
+        let elem = element.substring(0, element.indexOf(","));
+        const files = elem.split(/[0-9]+/).filter((elem1) => {
+          return elem1 != "";
+        });
+        const ranks = elem.split(/[a-z]+/).filter((elem1) => {
+          return elem1 != "";
+        });
+        return files[0] == files[1] && ranks[0] == ranks[1];
+      });
+    if (moves == null || moves.length == 0) {
+      alert(
+        "Cannot place a wall without moving currently. This variant does not allow walling or there are restrictions on walling without moving.",
+      );
+      return;
+    }
+    const wallmove = {
+      orig: moves[0].match(/[a-z]+[0-9]+/g)[0],
+      dest: moves[0].match(/[a-z]+[0-9]+/g)[1],
+    };
+    if (wallmove.orig == null || wallmove.dest == null) {
+      return;
+    }
+    afterChessgroundMove(wallmove.orig, wallmove.dest, {
       premove: false,
       ctrlKey: false,
       holdTime: 0,
@@ -3138,6 +3193,11 @@ function updateChessground() {
     } else {
       lastMoveFrom = lastMove.match(/[a-z]+[0-9]+/g)[0].replace("10", ":");
       lastMoveTo = lastMove.match(/[a-z]+[0-9]+/g)[1].replace("10", ":");
+      if (lastMoveFrom == lastMoveTo && lastMove.includes(",")) {
+        lastMoveFrom = lastMoveTo = lastMove
+          .match(/[a-z]+[0-9]+/g)[3]
+          .replace("10", ":");
+      }
     }
     chessground.set({
       lastMove: [lastMoveFrom, lastMoveTo],

--- a/src/main.js
+++ b/src/main.js
@@ -2919,24 +2919,30 @@ function afterChessgroundMove(orig, dest, metadata) {
 
   if (possiblegatings.length > 1) {
     //if there are more than one option
+    let i = 0;
+    let gatesquares = [];
+    for (i = 0; i < possiblegatings.length; i++) {
+      gatesquares.push(possiblegatings[i].match(/[a-z]+[0-9]+/g)[1]);
+    }
     while (true) {
       choice = prompt(
-        `There are multiple chioces that you can gate a wall square. They are\n${possiblegatings}\n, where = means do not gate, letters with numbers mean destination square (e.g. e4e5 means your piece has moved to e4 and you gate a wall square to e5). Now please enter your choice: `,
+        `There are multiple chioces that you can gate a wall square. They are\n${gatesquares}\n, where = means do not gate, letters with numbers mean destination square (e.g. e5 means you gate a wall square to e5). Now please enter your choice: `,
         "",
       );
       if (choice == null) {
         afterMove(false);
         return;
       }
-      if (possiblegatings.includes(choice)) {
+      if (gatesquares.includes(choice)) {
         break;
       } else {
         alert(
-          `Bad input: ${choice} . You should enter one option among ${possiblegatings}.`,
+          `Bad input: ${choice} . You should enter one option among ${gatesquares}.`,
         );
         continue;
       }
     }
+    choice = possiblegatings[gatesquares.indexOf(choice)];
   } else if (possiblegatings.length == 1) {
     //if there is only one option
     choice = possiblegatings[0];


### PR DESCRIPTION
## New Features
1. Added null move support. Users can double click a square to make a null move on that square.
2. Added Wall Or Move support for Atlantis and other variants that uses this rule. (Reported via Discord)

## Fixes
1. Fixed the display bug that being unable to display wall gating moves on \<Highlight Move\> button in "Show moves dialog" section.
2. Remove the redundant part of wall gating selection. Now users only need to provide the destination square.