### PR TITLE
Variant description & Wiki page link (if there is) for all built in variants & Random Mover

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Older browsers like Internet Explorer of any version are not supported.
 
 ## Run Engines Remotely
 
+> [!WARNING]
+> All binary engine loading features are experimental
+
 The definition of the terms used in this section:
 
 *__Server__*: The computer that runs the fairyground server (a console application) and the binary engines.
@@ -91,6 +94,9 @@ You need to build two connections, 9999 for HTTP and 9999 + 1 = 10000 for WebSoc
 Then browse to http://localhost:9999 on the client and if you see \<Engine Management\> button it works. Note that all the paths are paths *__on the server__*, *__NOT__* the path on the client. The binary executables of the engines need to be placed at respective paths *__on the server__*.
 
 ## Run External Binary Engines In Online Versions
+
+> [!WARNING]
+> All binary engine loading features are experimental
 
 The definition of the terms used in this section:
 

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1318,6 +1318,16 @@
       };
     }
 
+    function OpenURL(url) {
+      let link = document.createElement("a");
+      link.href = url;
+      link.id = "tmplink";
+      link.target = "_blank";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    }
+
     function getFileFromServer(url, doneCallback, errorCallback) {
       var xhr;
       function handleStateChange() {
@@ -4285,7 +4295,7 @@
                           `Variant ${name} (ID: ${$("#dropdown-variant").value}):\n${description}\n\nWiki: ${wiki}\n\nDo you want to visit the wiki page?`,
                         )
                       ) {
-                        window.open(wiki, "_blank");
+                        OpenURL(wiki);
                       }
                     } else {
                       window.alert(

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -1294,7 +1294,7 @@
     var fgs = window.fairyground.SavedGamesParsingFeature;
     let themes = [[], [], []];
     let themenames = [[], []];
-    let variantsettings = [[], [], [], []];
+    let variantsettings = [[], [], [], [], []];
     let allvariants = [];
     const $ = (...args) => document.querySelector(...args);
 
@@ -1462,7 +1462,7 @@
               continue;
             }
             variantdescriptionitem = rawText[i].split("|");
-            if (variantdescriptionitem.length != 4) {
+            if (variantdescriptionitem.length != 5) {
               console.warn(
                 `At line ${i + 1} in variantsettings.txt: Syntax error.`,
               );
@@ -1496,6 +1496,7 @@
             variantsettings[1].push(variantdescriptionitem[1]);
             variantsettings[2].push(variantdescriptionitem[2]);
             variantsettings[3].push(variantdescriptionitem[3]);
+            variantsettings[4].push(variantdescriptionitem[4]);
           }
           //console.log(variantsettings);
         } else {
@@ -1791,6 +1792,22 @@
         }
       } else {
         return variantsettings[3][index];
+      }
+    }
+
+    function getVariantWikiPageURL(variant, useplaceholder) {
+      if (typeof variant != "string" || typeof useplaceholder != "boolean") {
+        return null;
+      }
+      let index = variantsettings[0].indexOf(variant);
+      if (index < 0) {
+        if (useplaceholder) {
+          return "";
+        } else {
+          return undefined;
+        }
+      } else {
+        return variantsettings[4][index];
       }
     }
 
@@ -4257,10 +4274,24 @@
                     $("#dropdown-variant").value,
                     false,
                   );
+                  let wiki = getVariantWikiPageURL(
+                    $("#dropdown-variant").value,
+                    false,
+                  );
                   if (description) {
-                    window.alert(
-                      `Variant ${name} (ID: ${$("#dropdown-variant").value}):\n${description}`,
-                    );
+                    if (wiki) {
+                      if (
+                        window.confirm(
+                          `Variant ${name} (ID: ${$("#dropdown-variant").value}):\n${description}\n\nWiki: ${wiki}\n\nDo you want to visit the wiki page?`,
+                        )
+                      ) {
+                        window.open(wiki, "_blank");
+                      }
+                    } else {
+                      window.alert(
+                        `Variant ${name} (ID: ${$("#dropdown-variant").value}):\n${description}`,
+                      );
+                    }
                   } else {
                     window.alert(
                       "This variant does not provide a description. You can upload a variantsettings.txt yourself to add a description for it.",

--- a/public/advanced.html
+++ b/public/advanced.html
@@ -62,6 +62,11 @@
     margin-bottom: 10px;
   }
 
+  #input3 {
+    display: flex;
+    margin-bottom: 10px;
+  }
+
   #gamesettings {
     display: flex;
     margin-bottom: 10px;
@@ -1840,6 +1845,8 @@
       let during_play = false;
       let select_move_dialog = false;
       let in_browser_fsf_hash = 16;
+      let random_mover_white = false;
+      let random_mover_black = false;
       let white_start_time = 0;
       let black_start_time = 0;
       let white_remaining_time = 0;
@@ -2313,6 +2320,15 @@
             ) {
               setTimeout(go(false, true), 10);
             }
+          }
+          if (
+            (random_mover_white && !play_white && stm == "white") ||
+            (random_mover_black && !play_black && stm == "black")
+          ) {
+            setTimeout(() => {
+              if (random_mover_white || random_mover_black)
+                document.getElementById("randommovergo").click();
+            }, 200);
           }
         }
       };
@@ -3467,6 +3483,7 @@
         $("#currentposition").click();
         $("#input").style.display = "";
         $("#input2").style.display = "";
+        $("#input3").style.display = "";
         $("#posvariantdiv").style.display = "";
       };
 
@@ -3483,6 +3500,7 @@
         //We need to prevent user from doing unnecessary actions during countdown, so we'll hide these divs
         $("#input").style.display = "none"; //These divs are unable to be hidden by {hidden: during_play}
         $("#input2").style.display = "none";
+        $("#input3").style.display = "none";
         $("#posvariantdiv").style.display = "none";
         //$("#movecontrol").style.display = "none";
         resetTimer();
@@ -3506,10 +3524,8 @@
             (play_white && stm == "white") || (play_black && stm == "black")
           }`,
         );
-        if ((play_white && stm == "white") || (play_black && stm == "black")) {
-          console.log("Go!");
-          go(false, false);
-        }
+        console.log("Go!");
+        setFen(false, true);
       };
 
       const stop = (interrupt_pondering) => {
@@ -3532,7 +3548,11 @@
       };
 
       const force_stop = () => {
-        play_white = play_black = false;
+        play_white =
+          play_black =
+          random_mover_white =
+          random_mover_black =
+            false;
         play_move = false;
         stop(true);
       };
@@ -3861,50 +3881,63 @@
         }
 
         loadStockfish({ wasmBinary: data })
-          .then((_stockfish) => {
-            stockfish = _stockfish;
-            stockfish_state = "READY";
-            stockfish.addMessageListener((line) => {
-              if (line.startsWith("option")) {
-                if (line.startsWith("option name UCI_Variant")) {
-                  allvariants = line
-                    .replace(
-                      "option name UCI_Variant type combo default chess var ",
-                      "",
-                    )
-                    .replace(/ var /g, " ")
-                    .split(" ")
-                    .sort();
-                  //variants = allvariants;
-                  updateVariantTypeDropdown();
-                }
-              } else if (line.startsWith(" ")) {
-              } else {
-                if (!review_mode && line.startsWith("bestmove") && play_move) {
-                  play_move = false;
-                  if (analysis_mode) {
-                    return;
+          .then(
+            (_stockfish) => {
+              stockfish = _stockfish;
+              stockfish_state = "READY";
+              stockfish.addMessageListener((line) => {
+                if (line.startsWith("option")) {
+                  if (line.startsWith("option name UCI_Variant")) {
+                    allvariants = line
+                      .replace(
+                        "option name UCI_Variant type combo default chess var ",
+                        "",
+                      )
+                      .replace(/ var /g, " ")
+                      .split(" ")
+                      .sort();
+                    //variants = allvariants;
+                    updateVariantTypeDropdown();
                   }
-                  $("#move").value += " " + line.split(" ")[1];
-                  $("#set").click();
-                }
-                output2 += line + "\n";
-                if (fge.analysis_engine) {
-                  if (!fge.analysis_engine.IsUsing) {
+                } else if (line.startsWith(" ")) {
+                } else {
+                  if (
+                    !review_mode &&
+                    line.startsWith("bestmove") &&
+                    play_move
+                  ) {
+                    play_move = false;
+                    if (analysis_mode) {
+                      return;
+                    }
+                    $("#move").value += " " + line.split(" ")[1];
+                    $("#set").click();
+                  }
+                  output2 += line + "\n";
+                  if (fge.analysis_engine) {
+                    if (!fge.analysis_engine.IsUsing) {
+                      $("#engineoutputline").value = line;
+                      $("#engineoutputline").click();
+                    }
+                  } else {
                     $("#engineoutputline").value = line;
                     $("#engineoutputline").click();
                   }
-                } else {
-                  $("#engineoutputline").value = line;
-                  $("#engineoutputline").click();
                 }
-              }
-              m.redraw();
-            });
-            getVariants();
-          })
+                m.redraw();
+              });
+              getVariants();
+            },
+            (err) => {
+              console.error(err);
+              throw err;
+            },
+          )
           .catch((e) => {
             stockfish_state = "FAILED";
+            window.alert(
+              "There is something wrong with in browser Fairy-Stockfish. Press Ctrl+Shift+I to see more details.",
+            );
             throw e;
           })
           .finally(() => m.redraw());
@@ -4563,7 +4596,9 @@
                   play_white ||
                   play_black ||
                   advanced_time_control ||
-                  board_setup_mode,
+                  board_setup_mode ||
+                  random_mover_white ||
+                  random_mover_black,
                 onclick: () => {
                   analysis_mode = !analysis_mode;
                 },
@@ -4574,7 +4609,11 @@
               "label",
               m("input[type=checkbox]#playwhite", {
                 checked: play_white,
-                disabled: analysis_mode || review_mode || board_setup_mode,
+                disabled:
+                  analysis_mode ||
+                  review_mode ||
+                  board_setup_mode ||
+                  random_mover_white,
                 onclick: () => {
                   play_white = !play_white;
                 },
@@ -4585,7 +4624,11 @@
               "label",
               m("input[type=checkbox]#playblack", {
                 checked: play_black,
-                disabled: analysis_mode || review_mode || board_setup_mode,
+                disabled:
+                  analysis_mode ||
+                  review_mode ||
+                  board_setup_mode ||
+                  random_mover_black,
                 onclick: () => {
                   play_black = !play_black;
                 },
@@ -4593,30 +4636,34 @@
               "Engine black",
             ),
             m(
-              "label#label-advtimectrl",
-              m("input[type=checkbox]#advtimectrl", {
-                checked: advanced_time_control,
-                disabled: analysis_mode || review_mode || board_setup_mode,
-                onclick: () => {
-                  advanced_time_control = !advanced_time_control;
-                },
-              }),
-              "Advanced Time Control",
-            ),
-            m(
-              "label#label-boardsetup",
-              m("input[type=checkbox]#isboardsetup", {
-                checked: board_setup_mode,
+              "label",
+              m("input[type=checkbox]#randommoverwhite", {
+                checked: random_mover_white,
                 disabled:
                   analysis_mode ||
                   review_mode ||
-                  advanced_time_control ||
-                  select_move_dialog,
+                  board_setup_mode ||
+                  play_white,
                 onclick: () => {
-                  board_setup_mode = !board_setup_mode;
+                  random_mover_white = !random_mover_white;
                 },
               }),
-              "Board Setup",
+              "Random mover white",
+            ),
+            m(
+              "label",
+              m("input[type=checkbox]#randommoverblack", {
+                checked: random_mover_black,
+                disabled:
+                  analysis_mode ||
+                  review_mode ||
+                  board_setup_mode ||
+                  play_black,
+                onclick: () => {
+                  random_mover_black = !random_mover_black;
+                },
+              }),
+              "Random mover black",
             ),
             m("p#label-stm", { hidden: true }),
             m("input#displaymoves", {
@@ -4701,6 +4748,13 @@
               "Copy Set FEN (internal)",
             ),
             m(
+              "p#randommovergo",
+              {
+                hidden: true,
+              },
+              "Random Mover Go (internal)",
+            ),
+            m(
               "p#binengineoutputinit",
               {
                 hidden: true,
@@ -4774,6 +4828,35 @@
                 },
               },
               "Binary Engine Output Event Handler Initialization (internal)",
+            ),
+          ]),
+          m("div#input3", { hidden: during_play }, [
+            m("p", "Additional Features: "),
+            m(
+              "label#label-advtimectrl",
+              m("input[type=checkbox]#advtimectrl", {
+                checked: advanced_time_control,
+                disabled: analysis_mode || review_mode || board_setup_mode,
+                onclick: () => {
+                  advanced_time_control = !advanced_time_control;
+                },
+              }),
+              "Advanced Time Control",
+            ),
+            m(
+              "label#label-boardsetup",
+              m("input[type=checkbox]#isboardsetup", {
+                checked: board_setup_mode,
+                disabled:
+                  analysis_mode ||
+                  review_mode ||
+                  advanced_time_control ||
+                  select_move_dialog,
+                onclick: () => {
+                  board_setup_mode = !board_setup_mode;
+                },
+              }),
+              "Board Setup",
             ),
           ]),
           m(

--- a/public/themes.txt
+++ b/public/themes.txt
@@ -108,11 +108,13 @@ janggi|janggi|janggiboard
 janggicasual|@janggi|@janggi
 janggimodern|@janggi|@janggi
 janggitraditional|@janggi|@janggi
+janggihouse|@janggi|@janggi
 
 makruk|makruk|makrukboard
 makpong|@makruk|@makruk
 cambodian|@makruk|@makruk
 asean|asean|
+makhouse|@makruk|@makruk
 
 sittuyin|sittuyin|sittuyinboard
 

--- a/public/themes.txt
+++ b/public/themes.txt
@@ -101,6 +101,7 @@ dobutsu|dobutsu|dobutsuboard
 
 xiangqi|x2dhanzi,wikim|xiangqiboard
 xiangqihouse|@xiangqi|@xiangqi
+supply|@xiangqi|@xiangqi
 minixiangqi|@xiangqi|minixiangqiboard
 
 janggi|janggi|janggiboard

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -1,4 +1,4 @@
-#Fairyground Variant Settings File
+﻿#Fairyground Variant Settings File
 #Syntax: <variant ID (declared in variants.ini)>|<variant type/classification>|<variant display name>|<variant description>|<variant wiki page>
 #The type or classification is used in variant type dropdown which helps you classify the variants.
 #The display name will be displayed in the variant dropdown as the item name.
@@ -67,7 +67,7 @@ active|Chess Variants|Active Chess|9x9 variant with 2 queens each side.|https://
 advancedpawn|Chess Variants|Advanced Pawn Chess|Pawns have advanced one square at the beginning.|https://greenchess.net/rules.php?v=advanced-pawn
 captureall|Chess Variants|Capture All Chess|Capture all of your opponent's pieces to win.|https://greenchess.net/rules.php?v=capture-all
 cornerrook|Chess Variants|Corner Rook Chess|All pieces except rooks have advanced one square at the beginning.|https://greenchess.net/rules.php?v=corner-rook
-diana|Chess Variants|Diana Chess|Chess with no queens on a 6x6 board. No pawn double step and no en passant. Pawns cannot promote to bishops.|https://greenchess.net/rules.php?v=diana
+diana|Chess Variants|Diana Chess|Chess with no queens on a 6x6 board. No pawn double step and no en passant. Pawns cannot promote to queens.|https://greenchess.net/rules.php?v=diana
 microchess|Chess Variants|Micro Chess|Chess variant on a 4x5 board. There is no queen, and only a single pawn. No double step and castling.|https://greenchess.net/rules.php?v=microchess
 crossderby|Chess Variants|Cross Derby|Pawns promote to a knight on the 8th rank. Checkmate or stalemate your opponent to win the game.|https://www.chess.com/variants/cross-derby
 elimination|Chess Variants|Elimination Chess|Eliminate all the opponents' pieces but one to win. No checkmates, capturing is compulsory.|https://www.chess.com/variants/elimination-chess

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -6,6 +6,7 @@
 #The wiki page will be shown when users click <Variant INFO> button and click <Yes> or <OK>.
 #This can also be accessed from <Variant INFO> button.
 
+# Chess Variants: Variants based on Chess
 chess|Chess Variants|Chess|Chess, unmodified, as it's played by FIDE standards.|https://en.wikipedia.org/wiki/Chess
 fischerandom|Chess Variants|Fischer Random|Chess960. Pieces at the 1st/8th rank can be placed randomly but the bishops must be on squares of different colors and the king must be between the rooks. Special castling rules are applied.|https://en.wikipedia.org/wiki/Fischer_random_chess
 crazyhouse|Chess Variants|Crazy House|Take captured pieces and drop them back on to the board as your own.|https://en.wikipedia.org/wiki/Crazyhouse
@@ -19,11 +20,11 @@ giveaway|Chess Variants|Giveaway Chess|Lose all your pieces or get stalemated to
 antichess|Chess Variants|Anti Chess|Lose all your pieces or get stalemated to win. Capturing is compulsory. Kings are no longer royal and cannot castle.|https://lichess.org/variant/antichess
 suicide|Chess Variants|Suicide Chess|Lose all your pieces or have fewer pieces than the opponent's when getting stalemated to win. Capturing is compulsory. Kings are no longer royal and cannot castle.|https://www.freechess.org/Help/HelpFiles/suicide_chess.html
 losers|Chess Variants|Loser's Chess|Lose all your pieces except your king, get stalemated or get checkmated to win. Capturing is compulsory.|https://www.chessclub.com/help/Wild17
-torpedo|Chess Variants|Torpedo|Pawns can always move forward one or two squares.|https://arxiv.org/abs/2009.04374
+torpedo|Chess Variants|Torpedo Chess|Pawns can always move forward one or two squares.|https://arxiv.org/abs/2009.04374
 nocastle|Chess Variants|No Castling|Castling is not allowed.|
 pawnsideways|Chess Variants|Pawn Sideways|Pawns can also move sideways one square.|https://arxiv.org/abs/2009.04374
 pawnback|Chess Variants|Pawn Back|Pawns can also move back one square.|https://arxiv.org/abs/2009.04374
-knightmate|Chess Variants|Knight Mate|The king moves like a knight while the knights move like a king.|https://www.chessvariants.com/diffobjective.dir/knightmate.html
+knightmate|Chess Variants|Knight Mate|The king moves and captures like a knight while the knights move and capture like a king.|https://www.chessvariants.com/diffobjective.dir/knightmate.html
 armageddon|Chess Variants|Armageddon Chess|Chess but all draws are considered as win for black.|https://en.wikipedia.org/wiki/Fast_chess#Armageddon
 legan|Chess Variants|Legan Chess|Chess with pawn movements rotated by 45° counter-clockwise and different starting position.|https://en.wikipedia.org/wiki/Legan_chess
 extinction|Chess Variants|Extinction Chess|Capture all opponent pieces of a particular type to win. Promoted pieces are considered as their promoted form.|https://en.wikipedia.org/wiki/Extinction_chess
@@ -36,13 +37,70 @@ losalamos|Chess Variants|Los Alamos Chess|Chess with no bishops on a 6x6 board. 
 coregal|Chess Variants|Coregal Chess|Queens are also royal (i.e. can be checkmated) and can also castle. Pawns can promote to a queen and thus being royal.|https://www.chessvariants.com/winning.dir/coregal.html
 troitzky|Chess Variants|Troitzky Chess|Chess on a round board.|https://www.chessvariants.com/play/troitzky-chess
 jesonmor|Chess Variants|Jeson Mor|Player wins by being first to occupy the central square e5 with a knight, and then leave that square.|https://en.wikipedia.org/wiki/Jeson_Mor
-threekings|Chess Variants|Three Kings Chess|Rooks are replaced by kings. Any of the kings are checkmated is considered as a lose.|https://github.com/cutechess/cutechess/blob/master/projects/lib/src/board/threekingsboard.h
-petrified|Chess Variants|Petrified Chess|Pieces except pawns that capture a piece will turn into a wall square. Pawns can move sideways.|https://www.chess.com/variants/petrified
+threekings|Chess Variants|Three Kings Chess|Rooks are replaced by kings. Any of the kings being checkmated is a loss.|https://github.com/cutechess/cutechess/blob/master/projects/lib/src/board/threekingsboard.h
+petrified|Chess Variants|Petrified Chess|Pieces except pawns that capture a piece will turn into a wall square (called petrified). Pawns can move sideways.|https://www.chess.com/variants/petrified
 nocheckatomic|Chess Variants|No Check Atomic Chess|Atomic chess without checks. (ICC rules)|https://www.chessclub.com/help/atomic
-atomar|Chess Variants|Atomar Chess|Atomic Chess but Kings does not self explode or get blown up.|https://web.archive.org/web/20230519082613/https://chronatog.com/wp-content/uploads/2021/09/atomar-chess-rules.pdf
+atomar|Chess Variants|Atomar Chess|No Check Atomic Chess but Kings does not self explode or get blown up and cannot capture each other.|https://web.archive.org/web/20230519082613/https://chronatog.com/wp-content/uploads/2021/09/atomar-chess-rules.pdf
 5check|Chess Variants|5 Check|Check your opponent 5 times to win the game.|
 gardner|Chess Variants|Gardner's Mini Chess|5x5 chess. No double step and castling.|https://en.wikipedia.org/wiki/Minichess#5%C3%975_chess
+allwayspawns|Chess Variants|All Ways Pawns|Pawns with extra sideways and backwards movement.|
+3check-crazyhouse|Chess Variants|3 Check Crazy House|Hybrid variant of Three-Check Chess and Crazyhouse.|
+atomic-giveaway|Chess Variants|Atomic Giveaway Chess|Hybrid variant of Atomic and Giveaway.|
+atomic-giveaway-hill|Chess Variants|Atomic Giveaway King Of The Hill|Hybrid variant of Atomic, Giveaway, and King Of The Hill.|
+coffeehouse|Chess Variants|Coffee House|Crazyhouse with mandatory captures.|
+anti-losalamos|Chess Variants|Anti Los Alamos Chess|Hybrid variant of Anti Chess and Los Alamos.|
+upsidedown|Chess Variants|Upside-down Chess|The starting position of the pieces are inversed vertically.|
+peasant|Chess Variants|Peasant Revolt|Modest Chess variant with unequal armies (Knights versus Pawns) and standard Chess rules.|https://www.chessvariants.com/large.dir/peasantrevolt.html
+weak|Chess Variants|Weak Chess|Modest Chess variant with unequal armies (Knights + Pawns versus Standard Chess army) and standard Chess rules.|https://www.chessvariants.com/unequal.dir/weak.html
+semitorpedo|Chess Variants|Semi Torpedo Chess|Pawns can double step at 2nd and 3rd rank from the player's view.|
+pawnsonly|Chess Variants|Pawns Only|Capture all opponent's pieces or reach the farthest rank to win. Stalemate is a loss.|https://www.chessvariants.com/diffsetup.dir/pawnsonly.html
+pawnsking|Chess Variants|Pawns King|Checkmate opponent's king or move your king to the farthest rank to win. Pawns can only promote to queens.|https://github.com/yagu0/vchess/blob/master/client/src/translations/rules/Pawnsking/en.pug
+minihouse|Chess Variants|Mini House|6x6 version of crazyhouse with no queens and double step.|https://www.chess.com/variants/minihouse
+rookmate|Chess Variants|Rook Mate Chess|One of the rooks is royal, while the king is not royal.|https://www.chess.com/variants/rookmate
+capture|Chess Variants|Capture Chess|Capturing is compulsory.|https://vchess.club/#/variants/Capture
+doublearmy|Chess Variants|Double Army Chess|The army has been doubled and stacked. (The king at the back rank is royal)|https://vchess.club/#/variants/Doublearmy
+pawnsmassacre|Chess Variants|Pawns Massacre|The back rank pieces of different colors has switched their position.|https://vchess.club/#/variants/Pawnmassacre
+screen|Chess Variants|Screen Chess|Placement Chess but you can choose the starting position of all of your pieces including pawns. Pawns cannot placed on the same file.|https://vchess.club/#/variants/Screen
+crossing|Chess Variants|Crossing Chess|Move your king to the 5th rank from your view or checkmate opponent's king to win.|https://vchess.club/#/variants/Crossing
+active|Chess Variants|Active Chess|9x9 variant with 2 queens each side.|https://greenchess.net/rules.php?v=active
+6x6atom|Chess Variants|No Check Atomic Chess 6x6|6x6 version of No Check Atomic Chess.|
+advancedpawn|Chess Variants|Advanced Pawn Chess|Pawns have advanced one square at the beginning.|https://greenchess.net/rules.php?v=advanced-pawn
+captureall|Chess Variants|Capture All Chess|Capture all of your opponent's pieces to win.|https://greenchess.net/rules.php?v=capture-all
+cornerrook|Chess Variants|Corner Rook Chess|All pieces except rooks have advanced one square at the beginning.|https://greenchess.net/rules.php?v=corner-rook
+diana|Chess Variants|Diana Chess|Chess with no queens on a 6x6 board. No pawn double step and no en passant. Pawns cannot promote to bishops.|https://greenchess.net/rules.php?v=diana
+microchess|Chess Variants|Micro Chess|Chess variant on a 4x5 board. There is no queen, and only a single pawn. No double step and castling.|https://greenchess.net/rules.php?v=microchess
+crossderby|Chess Variants|Cross Derby|Pawns promote to a knight on the 8th rank. Checkmate or stalemate your opponent to win the game.|https://www.chess.com/variants/cross-derby
+elimination|Chess Variants|Elimination Chess|Eliminate all the opponents' pieces but one to win. No checkmates, capturing is compulsory.|https://www.chess.com/variants/elimination-chess
+antiatomic|Chess Variants|Anti Atomic Chess|Hybrid variant of atomic and giveaway.|
+atomiczh|Chess Variants|Atomic Crazy House|Hybrid of atomic and crazyhouse.|
+misere|Chess Variants|Misere Chess|Get checkmated to win.|
+dragonfly|Chess Variants|Dragonfly|Simplified Crazyhouse with no queens on 7x7 board. Pawns cannot be dropped and cannot double step.|https://en.wikipedia.org/wiki/Dragonfly_(chess_variant)
+kamikazerooks|Chess Variants|Kamikaze Rooks|Lose all your rooks to win.|
+racingchess|Chess Variants|Racing Chess|Win by campmate (moving the king to the farthest rank). No checks allowed.|
+twokings2|Chess Variants|Two Kings v2|A new king replaces the queen. Any of the kings being checkmated is a loss.|
+antiantichess|Chess Variants|Anti-Anti-Chess|Capture all your opponent's pieces or stalemate your opponent to win. Capturing is compulsory. Kings are no longer royal and cannot castle.|
+antihouse|Chess Variants|Anti Crazy House|Hybrid of antichess and crazyhouse. No castling.|
+coffeerace|Chess Variants|Coffee Race|Hybrid of racing kings and antichess.|
+epicatomic|Chess Variants|Epic Atomic Chess|Atomic with bigger board size and more pieces.|
+checkmateless|Chess Variants|Checkmateless Chess|Checks and checkmates can't be played. Stalemate your opponent to win.|https://lichess.org/forum/team-variant-testers/checkmateless-chess
+sixthrank|Chess Variants|Sixth Rank Chess|Move one pawn to the sixth rank to win.|https://lichess.org/forum/team-variant-testers/sixth-rank-chess
+backrank|Chess Variants|Backrank|Reach the last rank with any of your pieces or checkmate your opponent's king to win.|
+atomicduck|Chess Variants|Atomic Duck Chess|Hybrid of atomic chess and duck chess.|
+allexplodeatomic|Chess Variants|All Explode Atomic Chess|No Check Atomic Chess but pawns can also get blown up.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi/76202?do=show;id=83
+rooksquare|Chess Variants|Rooksquare Chess|Move any of your pieces to the corner squares on the opponent's side or checkmate opponent's king to win.|https://www.chessvariants.com/diffobjective.dir/rooksquare.html
+river|Chess Variants|River Chess|Get one of your pieces to the farthest rank to win. King is not royal.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=732
+nuclear|Chess Variants|Nuclear Chess|Atomic Chess but the piece capturing another one turns into a wall square after self explosion. Pawns can be blown up and petrified.|https://www.chessvariants.com/difftaking.dir/deadsquare.html
+castle|Chess Variants|Castle Chess|Black wins if black castles queen side while loses when black can longer castle queen side (i.e. moves the king without castling queen side). Standard rules apply.|https://www.chessvariants.com/winning.dir/castle.html
+squatter|Chess Variants|Squatter Chess|Move any piece to the farthest rank without being captured immediately next turn to win.|https://github.com/yagu0/vchess/blob/master/client/src/translations/rules/Squatter1/en.pug
+opposite-castling|Chess Variants|Opposite Castling Chess|Two players cannot castle the same side.|
+atlantis|Chess Variants|Atlantis Chess|Player may remove an empty square from the edge of the board instead of making a piece move. After a square is removed, more squares could be considered to belong to the edge of the board.|https://www.chessvariants.com/boardrules.dir/atlantis.html
+petty|Chess Variants|Petty Chess|5x6 variant with no castling and no double step.|https://www.chessvariants.com/small.dir/petty.html
+haynie|Chess Variants|Haynie's Primary Chess|6x6 variant with no knights.|https://www.chessvariants.com/small.dir/haynie.html
+argess|Chess Variants|Argess|Two sides have different asymmetric starting position where black surrounds white. Pawns can move orthogonally and capture diagonally.|https://www.chessvariants.com/diffsetup.dir/argess.html
+andersgiveaway|Chess Variants|Ander's Giveaway Chess|Giveaway Chess but you can pass your turn when no moves available.|
+andersanti|Chess Variants|Ander's Anti-Chess|Anti-Chess but you can pass your turn when no moves available.|
 
+# Makruk Variants: Variants based on Makruk
 makruk|Makruk Variants|Makruk|Thai Chess. A game closely resembling the original Chaturanga. Similar to Chess but with a different queen and bishop.|https://en.wikipedia.org/wiki/Makruk
 makpong|Makruk Variants|Makpong|Makruk variant where kings cannot move to escape out of check.|
 cambodian|Makruk Variants|Ouk Chatrang|Cambodian Chess. Makruk with a few additional opening abilities.|https://en.wikipedia.org/wiki/Makruk#Cambodian_chess
@@ -50,31 +108,41 @@ sittuyin|Makruk Variants|Sittuyin|Burmese Chess. Similar to Makruk, but pieces a
 asean|Makruk Variants|Asean|Makruk using the board/pieces from International Chess as well as pawn promotion rules.|http://hgm.nubati.net/rules/ASEAN.html
 karouk|Makruk Variants|Kar Ouk|A variant of Cambodian Chess (Ouk Chatrang) where the first check wins.|https://en.wikipedia.org/wiki/Makruk#Ka_Ouk
 ai-wok|Makruk Variants|Ai-wok|A makruk variant where the met is replaced by a super-piece moving as rook, knight, or met.|
+makhouse|Makruk Variants|Makruk House|Hybrid variant of Makruk and Crazyhouse.|
 
+# Shogi Variants: Variants based on Shogi
 shogi|Shogi Variants|Shogi|Japanese Chess, the standard 9x9 version played today with drops and promotions.|https://en.wikipedia.org/wiki/Shogi
 minishogi|Shogi Variants|Mini Shogi|5x5 Shogi for more compact and faster games. There are no knights or lances.|https://en.wikipedia.org/wiki/Minishogi
 kyotoshogi|Shogi Variants|Kyoto Shogi|A wild Shogi variant on a 5x5 board where pieces flip into a different piece after each move.|https://en.wikipedia.org/wiki/Kyoto_shogi
 dobutsu|Shogi Variants|Dobutsu Shogi|3x4 game with cute animals, designed to teach children how to play Shogi.|https://en.wikipedia.org/wiki/D%C5%8Dbutsu_sh%C5%8Dgi
 gorogoro|Shogi Variants|Gorogoro Shogi|5x6 Shogi designed to introduce tactics with the generals.|https://en.wikipedia.org/wiki/D%C5%8Dbutsu_sh%C5%8Dgi#Variation
-gorogoroplus|Shogi Variants|Gorogoro+ Shogi|Gorogoro Shogi with an addtional lance and an additional knight in the pocket.|
+gorogoroplus|Shogi Variants|Gorogoro+ Shogi|Gorogoro Shogi with an addtional lance and an additional knight in the pocket.|https://www.pychess.org/variants/gorogoroplus
 torishogi|Shogi Variants|Tori Shogi|A confrontational 7x7 variant with unique pieces each named after different birds.|https://en.wikipedia.org/wiki/Tori_shogi
 shoshogi|Shogi Variants|Sho Shogi|A new piece called Drunk Elephant is introduced, which can promote to a new king. You can lose one of the 2 kings after the promotion.|https://en.wikipedia.org/wiki/Sho_shogi
-cannonshogi|Shogi Variants|Cannon Shogi|Shogi with Chinese and Korean cannons.|
+cannonshogi|Shogi Variants|Cannon Shogi|Shogi with Chinese and Korean cannons.|https://www.chessvariants.com/shogivariants.dir/cannonshogi.html
 yarishogi|Shogi Variants|Yari Shogi|Shogi with movement of the pieces changed on a 7x9 board. See the wiki in <Variant INFO> for more details.|https://en.wikipedia.org/wiki/Yari_shogi
 okisakishogi|Shogi Variants|Okisaki Shogi|Shogi where Queens (Q) are added and the Shogi Knights (fN) are replaced with Chess Knights (N) on a 10x10 board.|https://en.wikipedia.org/wiki/Okisaki_shogi
 micro|Shogi Variants|Micro Shogi|Shogi on a 4x4 board where pieces promote on capture and can be dropped in their promoted form.|https://en.wikipedia.org/wiki/Micro_shogi
 euroshogi|Shogi Variants|Euro Shogi|Shogi on a 8x8 board where knights can also move sideways.|https://en.wikipedia.org/wiki/EuroShogi
 judkins|Shogi Variants|Judkins Shogi|6x6 Shogi with no lances.|https://en.wikipedia.org/wiki/Judkins_shogi
+antiminishogi|Shogi Variants|Anti Mini Shogi|Hybrid of antichess and minishogi.|
+gethenian|Shogi Variants|Gethenian Shogi|A Kyoto Shogi variant with a left/right theme.|
 
+# Xiangqi Variants: Variants based on Xiangqi
 xiangqi|Xiangqi Variants|Xiangqi|Chinese Chess, one of the oldest and most played board games in the world.|https://en.wikipedia.org/wiki/Xiangqi
 manchu|Xiangqi Variants|Manchu Xiangqi|Xiangqi variant where one side has a chariot that can also move as a cannon or horse.|https://en.wikipedia.org/wiki/Manchu_chess
 minixiangqi|Xiangqi Variants|Mini Xiangqi|Compact version of Xiangqi played on a 7x7 board without a river.|http://mlwi.magix.net/bg/minixiangqi.htm
+xiangqihouse|Xiangqi Variants|Xiangqi House|Hybrid variant of Xiangqi and Crazyhouse.|
+crowdedxiangqi|Xiangqi Variants|Crowded Xiangqi|Chinese Chess on half the board (5 × 9 intersections).|https://github.com/fairy-stockfish/Fairy-Stockfish/issues/180
 
+# Janggi Variants: Variants based on Janggi
 janggi|Janggi Variants|Janggi|Korean Chess, similar to Xiangqi but plays much differently. Tournament rules are used.|https://en.wikipedia.org/wiki/Janggi
 janggicasual|Janggi Variants|Janggi Casual|Korean Chess, similar to Xiangqi but plays much differently. Casual rules are used.|
 janggimodern|Janggi Variants|Janggi Modern|Korean Chess, similar to Xiangqi but plays much differently. Modern rules are used.|
 janggitraditional|Janggi Variants|Janggi Traditional|Korean Chess, similar to Xiangqi but plays much differently. Traditional rules are used.|
+janggihouse|Janggi Variants|Janggi House|Hybrid variant of janggi and crazyhouse. Tournament rules are used.|
 
+# Fairy Variants: Variants that have special piece moves and the goal is to checkmate opponent's king. Standard chess and regional variants (e.g. Shogi, Xiangqi, Janggi, Makruk) are not in this classification
 capablanca|Fairy Variants|Capablanca Chess|Play with the hybrid pieces, archbishop (B+N) and chancellor (R+N), on a 10x8 board.|https://en.wikipedia.org/wiki/Capablanca_Chess
 capahouse|Fairy Variants|Capablanca House|Capablanca with Crazyhouse drop rules.|
 seirawan|Fairy Variants|Seirawan Chess|S-Chess. Hybrid pieces, the hawk (B+N) and elephant (R+N), can enter the board after moving a back rank piece.|https://en.wikipedia.org/wiki/Seirawan_chess
@@ -87,8 +155,8 @@ hoppelpoppel|Fairy Variants|Hoppel-Poppel|Knights capture as bishops; bishops ca
 amazon|Fairy Variants|Amazon|Replace the Queen with Amazon (Q + N).|https://www.chessvariants.com/diffmove.dir/amazone.html
 gothic|Fairy Variants|Gothic Chess|Gothic chess. Capablanca chess with better starting position.|https://www.chessvariants.com/large.dir/gothicchess.html
 chaturanga|Fairy Variants|Chaturanga|Ancient form of chess. Pawns, bishops(elephants), and queen(ferz) are different from the ones in modern chess.|https://en.wikipedia.org/wiki/Chaturanga
-chak|Fairy Variants|Chak|Mayan chess. Inspired by cultural elements of Mesoamerica.|
-chennis|Fairy Variants|Chennis|Pieces alternate between two forms with each move.|
+chak|Fairy Variants|Chak|Mayan chess. Inspired by cultural elements of Mesoamerica.|https://www.pychess.org/variants/chak
+chennis|Fairy Variants|Chennis|Pieces alternate between two forms with each move.|https://www.pychess.org/variants/chennis
 mansindam|Fairy Variants|Mansindam|A variant that combines the Shogi's drop rule with strong pieces.|
 wolf|Fairy Variants|Wolf Chess|Play with the hybrid pieces, Fox (B+N) , Wolf (R+N), Nightrider (N0) and Sergeant (fKifmnD) on a 8x10 board.|https://en.wikipedia.org/wiki/Wolf_chess
 dragon|Fairy Variants|Dragon Chess|A Dragon (B+N) can be dropped at the 1st rank.|https://www.edami.com/dragonchess/
@@ -115,21 +183,48 @@ chancellor|Fairy Variants|Chancellor Chess|9x9 variant with Chancellors.|https:/
 janus|Fairy Variants|Janus Chess|10x8 variant with two archbishops per side.|https://en.wikipedia.org/wiki/Janus_Chess
 modern|Fairy Variants|Modern Chess|9x9 variant with archbishops.|https://en.wikipedia.org/wiki/Modern_chess
 perfect|Fairy Variants|Perfect Chess|General (Q + N), Chancellor (R + N) and Minister (B + N) are added to the game.|https://www.chessvariants.com/diffmove.dir/perfectchess.html
+indiangreat|Fairy Variants|Indian Great Chess|Giraffe (Q + N), Vizir (B + N) and War Machine (R + N) are introduced to the 10x10 board. Pawns cannot double step and only promote to queens.|https://www.chessvariants.com/historic.dir/indiangr1.html
+centaurking|Fairy Variants|Centaur King Chess|Kings can also move and capture like a knight.|
+gemini|Fairy Variants|Gemini Chess|Janus Chess with a different starting position.|
+caught-in-a-snag|Fairy Variants|Caught In A Snag|6x8 variant with lots of fairy pieces added (See wiki for more details). Stalemate is a win while pawns cannot promote.|https://www.chess.com/variants/caught-in-a-snag
+ordamirror|Fairy Variants|Orda Mirror Chess|Orda Chess variant with two Horde armies. The Falcon replaces the Yurt.|https://vchess.club/#/variants/Ordamirror
+gothhouse|Fairy Variants|Gothic House|Hybrid variant of Gothic Chess and crazyhouse.|
+wildebeest|Fairy Variants|Wildebeest|Camel (C) and Wildebeest (NC) or added to the 11x10 board.|https://vchess.club/#/variants/Wildebeest
+pandemonium|Fairy Variants|Pandemonium|A variant that combines drops and powerful pieces, and there is no draw.|https://www.chessvariants.com/rules/pandemonium
+#mounted|Fairy Variants|Mounted|
+shinobimirror|Fairy Variants|Shinobi Mirror|Both two sides has shinobi armies. Checkmate opponent's king or move your king to the farthest rank to win.|
+fullmoon|Fairy Variants|Fullmoon Chess|Archbishop (B + N) and Chancellor (R + N) can be dropped at the bottom rank. No castling and double step. Stalemate is a loss.|https://lichess.org/forum/team-variant-testers/fullmoon-chess-variant
+massacre|Fairy Variants|Massacre|Giveaway style game but the board is full of pieces.|https://brainking.com/en/GameRules?tp=128
+stardust|Fairy Variants|Stardust|Space-themed game and inspired in Star Wars.|
+cetus|Fairy Variants|Cetus|Ocean-themed game and inspired in whales and other marine mammals.|
+forward|Fairy Variants|Checkers Chess|Orthodox chess but pieces only move in forward direction, until they have reached the last row.|https://www.chessvariants.com/diffmove.dir/checkers.html
+xhess|Fairy Variants|Xhess|10x10 variant with many new pieces added. (See the wiki for more details)|https://www.chessvariants.com/large.dir/xhess.html
+1d-chess|Fairy Variants|1D Chess|Chess on 8x1 board.|https://ludii.games/details.php?keyword=1D%20Chess
+dragon-chess|Fairy Variants|Dragon Chess|Chess but all pieces can also move and capture like a king.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=1813
+blackletter|Fairy Variants|Blackletter Chess|9x10 variant with Archbishop (B + N), Chancellor (R + N) and Centaur (K + N) added.|https://www.chess.com/variants/blackletter-chess
+ajax-orthodox|Fairy Variants|Ajax Orthodox Chess|Bishops, Knights and Rook can also move (but not capture) like a king. Ajax-Minister (KAD) is introduced to the game which can be dropped at the back rank.|https://www.chessvariants.com/rules/ajax-orthodox-chess
+quasi-shatranj|Fairy Variants|4 Kings Quasi-Shatranj|Shatranj like game with short ranged pieces and 2 kings each side.|https://www.chessvariants.com/rules/4-kings-quasi-shatranj
 
-orda|Army Variants|Orda Chess|Asymmetric variant where one army has pieces that move like knights but capture differently.|
-synochess|Army Variants|Syno Chess|Asymmetric East vs. West variant which pits the western Chess army against a Xiangqi and Janggi-styled army.|
-shinobiplus|Army Variants|Shinobi+|Asymmetric variant which pits the western Chess army against a drop-based, Shogi-styled army.|
-empire|Army Variants|Empire Chess|Asymmetric variant where one army has pieces that move like queens but capture as usual.|
-ordamirror|Army Variants|Orda Mirror|Orda Chess variant with two Horde armies. The Falcon replaces the Yurt.|
-spartan|Army Variants|Spartan|Asymmetric Spartans vs. Persians variant.|https://www.chessvariants.com/rules/spartan-chess
-horde|Army Variants|Horde|Lots of pawns VS chess army. White wins when checkmating black while black wins when capturing all white pieces.|https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess
-khans|Army Variants|Khans Chess|Orda Chess variant. The scout and khatun replaces the pawn and yurt.|
+# Asymmetric Variants: Two sides have different pieces and there is at least one non pawn piece that have moves different from standard chess and regional variants (e.g. Shogi, Xiangqi, Janggi, Makruk)
+orda|Asymmetric Variants|Orda Chess|Asymmetric variant where one army has pieces that move like knights but capture differently.|
+synochess|Asymmetric Variants|Syno Chess|Asymmetric East vs. West variant which pits the western Chess army against a Xiangqi and Janggi-styled army.|
+shinobi|Asymmetric Variants|Shinobi Chess|Asymmetric variant which pits the western Chess army against a drop-based, Shogi-styled army.|https://vchess.club/#/variants/Shinobi
+shinobiplus|Asymmetric Variants|Shinobi+|More balanced version of Shinobi Chess.|https://www.pychess.org/variants/shinobiplus
+empire|Asymmetric Variants|Empire Chess|Asymmetric variant where one army has pieces that move like queens but capture as usual.|https://vchess.club/#/variants/Empire
+spartan|Asymmetric Variants|Spartan|Asymmetric Spartans vs. Persians variant.|https://www.chessvariants.com/rules/spartan-chess
+horde|Asymmetric Variants|Horde|Lots of pawns VS chess army. White wins when checkmating black while black wins when capturing all white pieces.|https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess
+khans|Asymmetric Variants|Khans Chess|Orda Chess variant. The scout and khatun replaces the pawn and yurt.|https://www.pychess.org/variants/khans
+maharajah|Asymmetric Variants|Mahajarah And The Sepoys|Asymmetric variant where the Mahajarah (Q + N) side wins by checkmating opponent's king while the Sepoy (full chess army) wins by checkmating Mahajarah.|https://en.wikipedia.org/wiki/Maharajah_and_the_Sepoys
+maharajah2|Asymmetric Variants|Mahajarah And The Sepoys 2|Balanced version of Maharajah and the Sepoys.|https://vchess.club/#/variants/Maharajah
+chessvshp|Asymmetric Variants|Chess vs Hoppel-Poppel|Asymmetrical game, Chess army vs Hoppel Poppel army.|
+ordavsempire|Asymmetric Variants|Orda vs Empire|Asymmetrical game, Empire army vs Orda army. Empire (as Black again), no Soldiers, 8 x Imperial Pawns but on the 3rd rank. Empire rules in place. Yurt is a mNcK.|
 
+# Rule Variants: Variants that have adjudication rules that does not contain checkmating and is not based on standard chess or regional variants (e.g. Shogi, Xiangqi, Janggi, Makruk)
 ataxx|Rule Variants|ATAXX|Infection game. Pieces can turn the enemy pieces in the 8 squares around the destination square into friendly pieces after move.|https://en.wikipedia.org/wiki/Ataxx
 amazons|Rule Variants|Game of the Amazons|Move queens and place a wall on squares in the 8 directions from the destination square. The last player able to move is the winner.|https://en.wikipedia.org/wiki/Game_of_the_Amazons
 breakthrough|Rule Variants|Breakthrough|The first player to reach the farthest rank by moving the piece (mfWfF) is the winner.|https://en.wikipedia.org/wiki/Breakthrough_(board_game)
 clobber|Rule Variants|Clobber|Players take turns to capture an opponent piece which is orthogonally adjacent to their own pieces. The one who cannot move loses.|https://en.wikipedia.org/wiki/Clobber
-cfour|Rule Variants|Connect Four|Be the first to form a horizontal, vertical, or diagonal line of four of one's own tokens to win.|https://en.wikipedia.org/wiki/Connect_Four
+cfour|Rule Variants|Connect Four|Be the first to form a orthogonal or diagonal line of four of one's own tokens to win.|https://en.wikipedia.org/wiki/Connect_Four
 tictactoe|Rule Variants|Tic-tac-toe|Noughts and Crosses. The player who succeeds in placing three of their marks in a horizontal, vertical, or diagonal row is the winner.|https://en.wikipedia.org/wiki/Tic-tac-toe
 flipersi|Rule Variants|Reversi|Drop your disk on a square that can enclose opponent disks lie in a straight line to turn those opponent disks color into yours. The one having more disks of that one's color wins when no moves are available.|https://en.wikipedia.org/wiki/Reversi
 flipello|Rule Variants|Othello|Reversi but players can pass their turn when they have no legal moves and the board has empty squares left.|https://en.wikipedia.org/wiki/Reversi#Othello
@@ -137,14 +232,46 @@ fox-and-hounds|Rule Variants|Fox and Hounds|Hounds (fF) hunting the fox (F). If 
 isolation|Rule Variants|Isolation|Players move their piece (K) and then place a wall square. The one who cannot move loses.|https://boardgamegeek.com/boardgame/1875/isolation
 joust|Rule Variants|Joust|The squares that pieces (N) have moved from will be blocked. The one who cannot move loses.|https://www.chessvariants.com/programs.dir/joust.html
 snailtrail|Rule Variants|Snail Trail|The squares that pieces (K) have moved from will be blocked. The one who cannot move loses.|https://boardgamegeek.com/boardgame/37135/snailtrail
-clobber10|Rule Variants|Clobber 10x10|Clobber on a 10x10 board, mainly played by computers|
-flipello10|Rule Variants|Reversi 10x10|Othello on a 10x10 board, mainly played by computers|
+clobber10|Rule Variants|Clobber 10x10|Clobber on a 10x10 board, mainly played by computers.|
+flipello10|Rule Variants|Othello 10x10|Othello on a 10x10 board, mainly played by computers.|
 isolation7x7|Rule Variants|Isolation 7x7|7x7 version of Isolation.|
+flipello6|Rule Variants|Othello 6x6|Othello on a 6x6 board.|
+buffalo|Rule Variants|Buffalo|Stalemating black all capture all black pieces to win as white. Reach the farthest rank to win as black.|https://boardgamegeek.com/boardgame/32/buffalo-chess
+knights-halma|Rule Variants|Knight's Halma|Move all your knights from their starting positions in your yard into the opponent's yard to win. Captures not allowed.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=1596
+hexapawn|Rule Variants|Hexapawn|Move one pawn to the farthest rank to win. Stalemate is a loss.|https://en.wikipedia.org/wiki/Hexapawn
+tuktuk|Rule Variants|T'uk T'uk|Pieces can move forward or backward for infinite squares. The one who cannot move loses.|https://ludii.games/details.php?keyword=T%27uk%20T%27uk
+aralzaa|Rule Variants|Aralzaa|Move all 3 knights to the farthest rank to win. Captures not allowed.|https://ludii.games/details.php?keyword=Aralzaa
+bajr|Rule Variants|Bajr|Move all your pawns from their starting positions in your yard into the opponent's yard to win. Captures not allowed.|https://ludii.games/variantDetails.php?keyword=Bajr&variant=1036
+lewthwaite|Rule Variants|Lewthwaite's Game|Move your pieces in the matrix to stalemate your opponent to win. Captures not allowed.|https://ludii.games/details.php?keyword=Lewthwaite%27s%20Game
+picaria|Rule Variants|Picaria|Drop and then move your pieces on the 3x3 board to make a three-in-a-row orthogonally or diagonally to win. Captures not allowed.|https://en.wikipedia.org/wiki/Picaria
+nineholes|Rule Variants|Nine Holes|Drop and then move your pieces on the 3x3 board to make a three-in-a-row orthogonally to win. Captures not allowed.|https://en.wikipedia.org/wiki/Nine_Holes
+tictacchess|Rule Variants|Tic-Tac-Chess|Drop and then move your rook, queen and king on the 3x3 board to make a three-in-a-row orthogonally or diagonally to win. Captures not allowed.|https://ludii.games/details.php?keyword=Tic-Tac-Chess
+asimplegame|Rule Variants|A Simple Game|Move your pieces on the 4x4 board to make a three-in-a-row orthogonally or diagonally to win. Captures not allowed.|https://ludii.games/details.php?keyword=A%20Simple%20Game
+alapo|Rule Variants|Alapo|Move one of your piece to the farthest rank without being captured immediately next turn to win.|https://www.chessvariants.org/small.dir/alapo.html
+allqueenschess|Rule Variants|All Queens Chess|Move your queens on the 5x5 board to make a four-in-a-row orthogonally or diagonally to win. Captures not allowed.|https://boardgamegeek.com/boardgame/34948/all-queens-chess
+capturethequeen|Rule Variants|Capture the Queen|Capture the black queen with the white pieces to win as white. All draws are considered as black win.|https://www.ludii.games/details.php?keyword=Capture%20the%20Queen
+cowboys|Rule Variants|Cowboys|Move the knights and gate a wall square one kinght move away from the destination square. Stalemate your opponent to win.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=237
+annexation|Rule Variants|Annexation|Othello on a non-square board.|
+nim|Rule Variants|Nim|Remove objects (represented as moving your piece forward, the blank squares between yours and opponent's pieces are objects left) from distinct heaps or piles (represented as a file). You must remove at least 1 from a heap for pile every turn. Avoid stalemate to win.|https://en.wikipedia.org/wiki/Nim
+roll-ing-to-four|Rule Variants|Roll-Ing to Four|Move your pieces on the 4x10 board to make a four-in-a-row orthogonally or diagonally to win. Captures not allowed.|https://www.ludii.games/details.php?keyword=Roll-Ing%20to%20Four
+quadwrangle|Rule Variants|Quad Wrangle|Move the pieces like a queen to turn opponent's ones on the 8 squares around the destination square to yours, or drop your pieces anywhere empty. The one with more pieces of own color wins when board is full.|https://www.ludii.games/details.php?keyword=Quad%20Wrangle
+crusade|Rule Variants|Crusade|Capture the opponent's pieces adjacent to your pieces and turn opponent's ones on the 8 squares around the destination square to yours. The one with more pieces of own color wins when stalemate.|https://www.ludii.games/details.php?keyword=Crusade
+snort|Rule Variants|Snort|Drop your pieces on empty squares that are not orthogonally adjacent to opponent's piece. The one with more pieces of own color wins when stalemate.|https://www.ludii.games/details.php?keyword=Snort
+gale|Rule Variants|Gale|Connect opposite sides of the square board with a chain of your pieces to win.|https://www.ludii.games/details.php?keyword=Gale
+teeko|Rule Variants|Teeko|Connect all of your pieces either a straight line (in any direction) or a close-knit square to win.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=655
+la-mancha-squeez|Rule Variants|La Mancha squeeZ|The squares that pieces (K) have moved from will be blocked. The one who cannot move loses.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=1367
+la-mancha-duel|Rule Variants|La Mancha Duel|The squares that pieces (K) have moved from will be blocked. Stalemate your opponent or capture all opponent pieces to win.|
+symphony|Rule Variants|Symphony|Move your pieces (mfsW) on the 8x8 board to make a four-in-a-row orthogonally or diagonally to win. Captures not allowed.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=1723
+cfour-anyside|Rule Variants|Roll 4|Roll your balls orthogonally from the edge into the board and it stops when hitting the board or another ball. Make a four-in-a-row orthogonally or diagonally to win.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=734
+cfour-misere|Rule Variants|Connect 4 Misere|Forming a orthogonal or diagonal line of four of one's own tokens is a loss. Avoid doing so and force your opponent to do it in order to win.|http://gamescrafters.berkeley.edu/games.php?game=connect4
+three-musketeers|Rule Variants|Three Musketeers|Musketeers (white) can only capture orthogonally adjacent pieces while Enemies (black) can only move to orthogonally adjacent squares. White wins when stalemate; Black wins when all white pieces are connected orthogonally.|
 
+# Not Supported Variants: Variants that have two boards. (e.g. Bughouse, Alice Chess)
 bughouse|(not supported)|Bughouse Chess|Team work chess where 4 players play on 2 boards in teams of 2. Captured pieces on one board are passed on to the teammate on the other board, who then has the option of dropping these pieces on their board.|https://en.wikipedia.org/wiki/Bughouse_chess
 koedem|(not supported)|Koedem|Bughouse Chess but kings can be captured and then immediately given to teammate whose next move has to play that king. The team has all four kings wins.|http://schachclub-oetigheim.de/wp-content/uploads/2016/04/Koedem-rules.pdf
 supply|(not supported)|Supply Xiangqi|Xiangqi Bughouse.|https://en.wikipedia.org/wiki/Xiangqi#Variations
 
+# Only used for internal purposes
 fairy|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for endgame initialization.|
 mini|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for internal purposes.|
 normal|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for internal purposes.|

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -91,7 +91,7 @@ rooksquare|Chess Variants|Rooksquare Chess|Move any of your pieces to the corner
 river|Chess Variants|River Chess|Get one of your pieces to the farthest rank to win. King is not royal.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=732
 nuclear|Chess Variants|Nuclear Chess|Atomic Chess but the piece capturing another one turns into a wall square after self explosion. Pawns can be blown up and petrified.|https://www.chessvariants.com/difftaking.dir/deadsquare.html
 castle|Chess Variants|Castle Chess|Black wins if black castles queen side while loses when black can longer castle queen side (i.e. moves the king without castling queen side). Standard rules apply.|https://www.chessvariants.com/winning.dir/castle.html
-squatter|Chess Variants|Squatter Chess|Move any piece to the farthest rank without being captured immediately next turn to win.|https://github.com/yagu0/vchess/blob/master/client/src/translations/rules/Squatter1/en.pug
+squatter|Chess Variants|Squatter Chess|Move any piece to the farthest rank without being captured immediately next turn or checkmate opponent's king to win.|https://github.com/yagu0/vchess/blob/master/client/src/translations/rules/Squatter1/en.pug
 opposite-castling|Chess Variants|Opposite Castling Chess|Two players cannot castle the same side.|
 atlantis|Chess Variants|Atlantis Chess|Player may remove an empty square from the edge of the board instead of making a piece move. After a square is removed, more squares could be considered to belong to the edge of the board.|https://www.chessvariants.com/boardrules.dir/atlantis.html
 petty|Chess Variants|Petty Chess|5x6 variant with no castling and no double step.|https://www.chessvariants.com/small.dir/petty.html

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -1,4 +1,4 @@
-﻿#Fairyground Variant Settings File
+#Fairyground Variant Settings File
 #Syntax: <variant ID (declared in variants.ini)>|<variant type/classification>|<variant display name>|<variant description>|<variant wiki page>
 #The type or classification is used in variant type dropdown which helps you classify the variants.
 #The display name will be displayed in the variant dropdown as the item name.
@@ -236,7 +236,7 @@ clobber10|Rule Variants|Clobber 10x10|Clobber on a 10x10 board, mainly played by
 flipello10|Rule Variants|Othello 10x10|Othello on a 10x10 board, mainly played by computers.|
 isolation7x7|Rule Variants|Isolation 7x7|7x7 version of Isolation.|
 flipello6|Rule Variants|Othello 6x6|Othello on a 6x6 board.|
-buffalo|Rule Variants|Buffalo|Stalemating black all capture all black pieces to win as white. Reach the farthest rank to win as black.|https://boardgamegeek.com/boardgame/32/buffalo-chess
+buffalo|Rule Variants|Buffalo|Stalemate black or capture all black pieces to win as white. Reach the farthest rank to win as black.|https://boardgamegeek.com/boardgame/32/buffalo-chess
 knights-halma|Rule Variants|Knight's Halma|Move all your knights from their starting positions in your yard into the opponent's yard to win. Captures not allowed.|https://www.zillions-of-games.com/cgi-bin/zilligames/submissions.cgi?do=show;id=1596
 hexapawn|Rule Variants|Hexapawn|Move one pawn to the farthest rank to win. Stalemate is a loss.|https://en.wikipedia.org/wiki/Hexapawn
 tuktuk|Rule Variants|T'uk T'uk|Pieces can move forward or backward for infinite squares. The one who cannot move loses.|https://ludii.games/details.php?keyword=T%27uk%20T%27uk

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -69,7 +69,6 @@ judkins|Shogi Variants|Judkins Shogi|6x6 Shogi with no lances.|https://en.wikipe
 xiangqi|Xiangqi Variants|Xiangqi|Chinese Chess, one of the oldest and most played board games in the world.|https://en.wikipedia.org/wiki/Xiangqi
 manchu|Xiangqi Variants|Manchu Xiangqi|Xiangqi variant where one side has a chariot that can also move as a cannon or horse.|https://en.wikipedia.org/wiki/Manchu_chess
 minixiangqi|Xiangqi Variants|Mini Xiangqi|Compact version of Xiangqi played on a 7x7 board without a river.|http://mlwi.magix.net/bg/minixiangqi.htm
-supply|Xiangqi Variants|Supply Xiangqi|Xiangqi Bughouse.|https://en.wikipedia.org/wiki/Xiangqi#Variations
 
 janggi|Janggi Variants|Janggi|Korean Chess, similar to Xiangqi but plays much differently. Tournament rules are used.|https://en.wikipedia.org/wiki/Janggi
 janggicasual|Janggi Variants|Janggi Casual|Korean Chess, similar to Xiangqi but plays much differently. Casual rules are used.|
@@ -144,6 +143,7 @@ isolation7x7|Rule Variants|Isolation 7x7|7x7 version of Isolation.|
 
 bughouse|(not supported)|Bughouse Chess|Team work chess where 4 players play on 2 boards in teams of 2. Captured pieces on one board are passed on to the teammate on the other board, who then has the option of dropping these pieces on their board.|https://en.wikipedia.org/wiki/Bughouse_chess
 koedem|(not supported)|Koedem|Bughouse Chess but kings can be captured and then immediately given to teammate whose next move has to play that king. The team has all four kings wins.|http://schachclub-oetigheim.de/wp-content/uploads/2016/04/Koedem-rules.pdf
+supply|(not supported)|Supply Xiangqi|Xiangqi Bughouse.|https://en.wikipedia.org/wiki/Xiangqi#Variations
 
 fairy|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for endgame initialization.|
 mini|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for internal purposes.|

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -1,74 +1,150 @@
 #Fairyground Variant Settings File
-#Syntax: <variant ID (declared in variants.ini)>|<variant type/classification>|<variant display name>|<variant description>
+#Syntax: <variant ID (declared in variants.ini)>|<variant type/classification>|<variant display name>|<variant description>|<variant wiki page>
 #The type or classification is used in variant type dropdown which helps you classify the variants.
 #The display name will be displayed in the variant dropdown as the item name.
 #The description will be displayed in the dropdown as tooltips, you can hover your cursor on an item to view that.
-#This can also be accessed from <About This Variant> button.
+#The wiki page will be shown when users click <Variant INFO> button and click <Yes> or <OK>.
+#This can also be accessed from <Variant INFO> button.
 
-chess|Chess Variants|Chess|Chess, unmodified, as it's played by FIDE standards.
-crazyhouse|Chess Variants|Crazy House|Take captured pieces and drop them back on to the board as your own.
-atomic|Chess Variants|Atomic Chess|Pieces explode upon capture, destroying all pieces except pawns in the 8 square around the destination square and itself.
-kingofthehill|Chess Variants|King Of The Hill|Bring your King to the center to win the game.
-3check|Chess Variants|3 Check|Check your opponent 3 times to win the game.
-placement|Chess Variants|Placement Chess|Choose where your pieces start.
-duck|Chess Variants|Duck Chess|The duck (a wall square that blocks any piece from moving to it) must be moved to a new square after every turn.
-racingkings|Chess Variants|Racing Kings|Hinder the opponent's king and make your king reach the 8th rank first to win. Checks are not allowed.
-giveaway|Chess Variants|Giveaway Chess|Lose all your pieces or get stalemated to win. Capturing is compulsory.
-torpedo|Chess Variants|Torpedo|Pawns can always move forward one or two squares.
-nocastle|Chess Variants|No Castling|Castling is not allowed.
-pawnsideways|Chess Variants|Pawns Sideways|Pawns can also move sideways one square.
-knightmate|Chess Variants|Knight Mate|The king moves like a knight while the knights move like a king.
+chess|Chess Variants|Chess|Chess, unmodified, as it's played by FIDE standards.|https://en.wikipedia.org/wiki/Chess
+fischerandom|Chess Variants|Fischer Random|Chess960. Pieces at the 1st/8th rank can be placed randomly but the bishops must be on squares of different colors and the king must be between the rooks. Special castling rules are applied.|https://en.wikipedia.org/wiki/Fischer_random_chess
+crazyhouse|Chess Variants|Crazy House|Take captured pieces and drop them back on to the board as your own.|https://en.wikipedia.org/wiki/Crazyhouse
+atomic|Chess Variants|Atomic Chess|Pieces explode upon capture, destroying all pieces except pawns in the 8 square around the destination square and itself.|https://en.wikipedia.org/wiki/Atomic_chess
+kingofthehill|Chess Variants|King Of The Hill|Bring your King to the center to win the game.|https://en.wikipedia.org/wiki/King_of_the_Hill_(chess)
+3check|Chess Variants|3 Check|Check your opponent 3 times to win the game.|https://en.wikipedia.org/wiki/Three-check_chess
+placement|Chess Variants|Placement Chess|Choose where your pieces start.|https://www.chessvariants.com/link/placement-chess
+duck|Chess Variants|Duck Chess|The duck (a wall square that blocks any piece from moving to it) must be moved to a new square after every turn.|https://duckchess.com/
+racingkings|Chess Variants|Racing Kings|Hinder the opponent's king and make your king reach the 8th rank first to win. Checks are not allowed.|https://en.wikipedia.org/wiki/V._R._Parton#Racing_Kings
+giveaway|Chess Variants|Giveaway Chess|Lose all your pieces or get stalemated to win. Capturing is compulsory. Kings are no longer royal.|http://www.chessvariants.com/diffobjective.dir/giveaway.old.html
+antichess|Chess Variants|Anti Chess|Lose all your pieces or get stalemated to win. Capturing is compulsory. Kings are no longer royal and cannot castle.|https://lichess.org/variant/antichess
+suicide|Chess Variants|Suicide Chess|Lose all your pieces or have fewer pieces than the opponent's when getting stalemated to win. Capturing is compulsory. Kings are no longer royal and cannot castle.|https://www.freechess.org/Help/HelpFiles/suicide_chess.html
+losers|Chess Variants|Loser's Chess|Lose all your pieces except your king, get stalemated or get checkmated to win. Capturing is compulsory.|https://www.chessclub.com/help/Wild17
+torpedo|Chess Variants|Torpedo|Pawns can always move forward one or two squares.|https://arxiv.org/abs/2009.04374
+nocastle|Chess Variants|No Castling|Castling is not allowed.|
+pawnsideways|Chess Variants|Pawn Sideways|Pawns can also move sideways one square.|https://arxiv.org/abs/2009.04374
+pawnback|Chess Variants|Pawn Back|Pawns can also move back one square.|https://arxiv.org/abs/2009.04374
+knightmate|Chess Variants|Knight Mate|The king moves like a knight while the knights move like a king.|https://www.chessvariants.com/diffobjective.dir/knightmate.html
+armageddon|Chess Variants|Armageddon Chess|Chess but all draws are considered as win for black.|https://en.wikipedia.org/wiki/Fast_chess#Armageddon
+legan|Chess Variants|Legan Chess|Chess with pawn movements rotated by 45° counter-clockwise and different starting position.|https://en.wikipedia.org/wiki/Legan_chess
+extinction|Chess Variants|Extinction Chess|Capture all opponent pieces of a particular type to win. Promoted pieces are considered as their promoted form.|https://en.wikipedia.org/wiki/Extinction_chess
+codrus|Chess Variants|Codrus Chess|Lose your king to win the game. Capturing is compulsory.|http://www.binnewirtz.com/Schlagschach1.htm
+pocketknight|Chess Variants|Pocket Knight|Players take an extra knight at beginning and can drop it on the board.|https://www.chessvariants.com/other.dir/pocket.html
+kinglet|Chess Variants|Kinglet Chess|Capture all opponent's pawns to win. Kings are no longer royal.|https://en.wikipedia.org/wiki/V._R._Parton#Kinglet_chess
+loop|Chess Variants|Loop Chess|Crazy house where promoted pieces keep their rank when captured.|https://en.wikipedia.org/wiki/Crazyhouse#Variations
+chessgi|Chess Variants|Chessgi|Crazy house where promoted pieces keep their rank when captured and pawns may be dropped on its 1st rank.|https://en.wikipedia.org/wiki/Crazyhouse#Variations
+losalamos|Chess Variants|Los Alamos Chess|Chess with no bishops on a 6x6 board. No castling, no pawn double step and no en passant. Pawns cannot promote to bishops.|https://en.wikipedia.org/wiki/Los_Alamos_chess
+coregal|Chess Variants|Coregal Chess|Queens are also royal (i.e. can be checkmated) and can also castle. Pawns can promote to a queen and thus being royal.|https://www.chessvariants.com/winning.dir/coregal.html
+troitzky|Chess Variants|Troitzky Chess|Chess on a round board.|https://www.chessvariants.com/play/troitzky-chess
+jesonmor|Chess Variants|Jeson Mor|Player wins by being first to occupy the central square e5 with a knight, and then leave that square.|https://en.wikipedia.org/wiki/Jeson_Mor
+threekings|Chess Variants|Three Kings Chess|Rooks are replaced by kings. Any of the kings are checkmated is considered as a lose.|https://github.com/cutechess/cutechess/blob/master/projects/lib/src/board/threekingsboard.h
+petrified|Chess Variants|Petrified Chess|Pieces except pawns that capture a piece will turn into a wall square. Pawns can move sideways.|https://www.chess.com/variants/petrified
+nocheckatomic|Chess Variants|No Check Atomic Chess|Atomic chess without checks. (ICC rules)|https://www.chessclub.com/help/atomic
+atomar|Chess Variants|Atomar Chess|Atomic Chess but Kings does not self explode or get blown up.|https://web.archive.org/web/20230519082613/https://chronatog.com/wp-content/uploads/2021/09/atomar-chess-rules.pdf
+5check|Chess Variants|5 Check|Check your opponent 5 times to win the game.|
+gardner|Chess Variants|Gardner's Mini Chess|5x5 chess. No double step and castling.|https://en.wikipedia.org/wiki/Minichess#5%C3%975_chess
 
-makruk|Makruk Variants|Makruk|Thai Chess. A game closely resembling the original Chaturanga. Similar to Chess but with a different queen and bishop.
-makpong|Makruk Variants|Makpong|Makruk variant where kings cannot move to escape out of check.
-cambodian|Makruk Variants|Ouk Chatrang|Cambodian Chess. Makruk with a few additional opening abilities.
-sittuyin|Makruk Variants|Sittuyin|Burmese Chess. Similar to Makruk, but pieces are placed at the start of the match.
-asean|Makruk Variants|Asean|Makruk using the board/pieces from International Chess as well as pawn promotion rules.
+makruk|Makruk Variants|Makruk|Thai Chess. A game closely resembling the original Chaturanga. Similar to Chess but with a different queen and bishop.|https://en.wikipedia.org/wiki/Makruk
+makpong|Makruk Variants|Makpong|Makruk variant where kings cannot move to escape out of check.|
+cambodian|Makruk Variants|Ouk Chatrang|Cambodian Chess. Makruk with a few additional opening abilities.|https://en.wikipedia.org/wiki/Makruk#Cambodian_chess
+sittuyin|Makruk Variants|Sittuyin|Burmese Chess. Similar to Makruk, but pieces are placed at the start of the match.|https://en.wikipedia.org/wiki/Sittuyin
+asean|Makruk Variants|Asean|Makruk using the board/pieces from International Chess as well as pawn promotion rules.|http://hgm.nubati.net/rules/ASEAN.html
+karouk|Makruk Variants|Kar Ouk|A variant of Cambodian Chess (Ouk Chatrang) where the first check wins.|https://en.wikipedia.org/wiki/Makruk#Ka_Ouk
+ai-wok|Makruk Variants|Ai-wok|A makruk variant where the met is replaced by a super-piece moving as rook, knight, or met.|
 
-shogi|Shogi Variants|Shogi|Japanese Chess, the standard 9x9 version played today with drops and promotions.
-minishogi|Shogi Variants|Mini Shogi|5x5 Shogi for more compact and faster games. There are no knights or lances.
-kyotoshogi|Shogi Variants|Kyoto Shogi|A wild Shogi variant on a 5x5 board where pieces flip into a different piece after each move.
-dobutsu|Shogi Variants|Dobutsu Shogi|3x4 game with cute animals, designed to teach children how to play Shogi.
-gorogoro|Shogi Variants|Gorogoro Shogi|5x6 Shogi designed to introduce tactics with the generals.
-gorogoroplus|Shogi Variants|Gorogoro+ Shogi|5x6 Shogi designed to introduce tactics with the generals.
-torishogi|Shogi Variants|Tori Shogi|A confrontational 7x7 variant with unique pieces each named after different birds.
-shoshogi|Shogi Variants|Sho Shogi|A new piece called Drunk Elephant is introduced, which can promote to a new king. You can lose one of the 2 kings after the promotion.
-cannonshogi|Shogi Variants|Cannon Shogi|Shogi with Chinese and Korean cannons.
+shogi|Shogi Variants|Shogi|Japanese Chess, the standard 9x9 version played today with drops and promotions.|https://en.wikipedia.org/wiki/Shogi
+minishogi|Shogi Variants|Mini Shogi|5x5 Shogi for more compact and faster games. There are no knights or lances.|https://en.wikipedia.org/wiki/Minishogi
+kyotoshogi|Shogi Variants|Kyoto Shogi|A wild Shogi variant on a 5x5 board where pieces flip into a different piece after each move.|https://en.wikipedia.org/wiki/Kyoto_shogi
+dobutsu|Shogi Variants|Dobutsu Shogi|3x4 game with cute animals, designed to teach children how to play Shogi.|https://en.wikipedia.org/wiki/D%C5%8Dbutsu_sh%C5%8Dgi
+gorogoro|Shogi Variants|Gorogoro Shogi|5x6 Shogi designed to introduce tactics with the generals.|https://en.wikipedia.org/wiki/D%C5%8Dbutsu_sh%C5%8Dgi#Variation
+gorogoroplus|Shogi Variants|Gorogoro+ Shogi|Gorogoro Shogi with an addtional lance and an additional knight in the pocket.|
+torishogi|Shogi Variants|Tori Shogi|A confrontational 7x7 variant with unique pieces each named after different birds.|https://en.wikipedia.org/wiki/Tori_shogi
+shoshogi|Shogi Variants|Sho Shogi|A new piece called Drunk Elephant is introduced, which can promote to a new king. You can lose one of the 2 kings after the promotion.|https://en.wikipedia.org/wiki/Sho_shogi
+cannonshogi|Shogi Variants|Cannon Shogi|Shogi with Chinese and Korean cannons.|
+yarishogi|Shogi Variants|Yari Shogi|Shogi with movement of the pieces changed on a 7x9 board. See the wiki in <Variant INFO> for more details.|https://en.wikipedia.org/wiki/Yari_shogi
+okisakishogi|Shogi Variants|Okisaki Shogi|Shogi where Queens (Q) are added and the Shogi Knights (fN) are replaced with Chess Knights (N) on a 10x10 board.|https://en.wikipedia.org/wiki/Okisaki_shogi
+micro|Shogi Variants|Micro Shogi|Shogi on a 4x4 board where pieces promote on capture and can be dropped in their promoted form.|https://en.wikipedia.org/wiki/Micro_shogi
+euroshogi|Shogi Variants|Euro Shogi|Shogi on a 8x8 board where knights can also move sideways.|https://en.wikipedia.org/wiki/EuroShogi
+judkins|Shogi Variants|Judkins Shogi|6x6 Shogi with no lances.|https://en.wikipedia.org/wiki/Judkins_shogi
 
-xiangqi|Xiangqi Variants|Xiangqi|Chinese Chess, one of the oldest and most played board games in the world.
-manchu|Xiangqi Variants|Manchu Xiangqi|Xiangqi variant where one side has a chariot that can also move as a cannon or horse.
-minixiangqi|Xiangqi Variants|Mini Xiangqi|Compact version of Xiangqi played on a 7x7 board without a river.
+xiangqi|Xiangqi Variants|Xiangqi|Chinese Chess, one of the oldest and most played board games in the world.|https://en.wikipedia.org/wiki/Xiangqi
+manchu|Xiangqi Variants|Manchu Xiangqi|Xiangqi variant where one side has a chariot that can also move as a cannon or horse.|https://en.wikipedia.org/wiki/Manchu_chess
+minixiangqi|Xiangqi Variants|Mini Xiangqi|Compact version of Xiangqi played on a 7x7 board without a river.|http://mlwi.magix.net/bg/minixiangqi.htm
+supply|Xiangqi Variants|Supply Xiangqi|Xiangqi Bughouse.|https://en.wikipedia.org/wiki/Xiangqi#Variations
 
-janggi|Janggi Variants|Janggi|Korean Chess, similar to Xiangqi but plays much differently. Tournament rules are used.
-janggicasual|Janggi Variants|Janggi Casual|Korean Chess, similar to Xiangqi but plays much differently. Casual rules are used.
-janggimodern|Janggi Variants|Janggi Modern|Korean Chess, similar to Xiangqi but plays much differently. Modern rules are used.
-janggitraditional|Janggi Variants|Janggi Traditional|Korean Chess, similar to Xiangqi but plays much differently. Traditional rules are used.
+janggi|Janggi Variants|Janggi|Korean Chess, similar to Xiangqi but plays much differently. Tournament rules are used.|https://en.wikipedia.org/wiki/Janggi
+janggicasual|Janggi Variants|Janggi Casual|Korean Chess, similar to Xiangqi but plays much differently. Casual rules are used.|
+janggimodern|Janggi Variants|Janggi Modern|Korean Chess, similar to Xiangqi but plays much differently. Modern rules are used.|
+janggitraditional|Janggi Variants|Janggi Traditional|Korean Chess, similar to Xiangqi but plays much differently. Traditional rules are used.|
 
-capablanca|Fairy Variants|Capablanca Chess|Play with the hybrid pieces, archbishop (B+N) and chancellor (R+N), on a 10x8 board.
-capahouse|Fairy Variants|Capablanca House|Capablanca with Crazyhouse drop rules.
-seirawan|Fairy Variants|Seirawan Chess|S-Chess. Hybrid pieces, the hawk (B+N) and elephant (R+N), can enter the board after moving a back rank piece.
-shouse|Fairy Variants|Seirawan House|S-Chess with Crazyhouse drop rules.
-grand|Fairy Variants|Grand Chess|Play with the hybrid pieces, archbishop (B+N) and chancellor (R+N), on a grand 10x10 board.
-grandhouse|Fairy Variants|Grand House|Grand Chess with Crazyhouse drop rules.
-shako|Fairy Variants|Shako|Introduces the cannon and elephant from Xiangqi into a 10x10 chess board.
-shogun|Fairy Variants|Shogun|Pieces promote and can be dropped, similar to Shogi.
-hoppelpoppel|Fairy Variants|Hoppel-Poppel|Knights capture as bishops; bishops capture as knights.
-amazon|Fairy Variants|Amazon|Replace the Queen with Amazon (Q + N).
-gothic|Fairy Variants|Gothic Chess|Gothic chess. Capablanca chess with better starting position.
-chaturanga|Fairy Variants|Chaturanga|Ancient form of chess. Pawns, bishops(elephants), and queen(ferz) are different from the ones in modern chess.
-chak|Fairy Variants|Chak|Mayan chess. Inspired by cultural elements of Mesoamerica.
-chennis|Fairy Variants|Chennis|Pieces alternate between two forms with each move.
-mansindam|Fairy Variants|Mansindam|A variant that combines the Shogi's drop rule with strong pieces.
+capablanca|Fairy Variants|Capablanca Chess|Play with the hybrid pieces, archbishop (B+N) and chancellor (R+N), on a 10x8 board.|https://en.wikipedia.org/wiki/Capablanca_Chess
+capahouse|Fairy Variants|Capablanca House|Capablanca with Crazyhouse drop rules.|
+seirawan|Fairy Variants|Seirawan Chess|S-Chess. Hybrid pieces, the hawk (B+N) and elephant (R+N), can enter the board after moving a back rank piece.|https://en.wikipedia.org/wiki/Seirawan_chess
+shouse|Fairy Variants|Seirawan House|S-Chess with Crazyhouse drop rules.|
+grand|Fairy Variants|Grand Chess|Play with the hybrid pieces, archbishop (B+N) and chancellor (R+N), on a grand 10x10 board.|https://en.wikipedia.org/wiki/Grand_Chess
+grandhouse|Fairy Variants|Grand House|Grand Chess with Crazyhouse drop rules.|
+shako|Fairy Variants|Shako|Introduces the cannon and elephant from Xiangqi into a 10x10 chess board.|https://www.chessvariants.com/large.dir/shako.html
+shogun|Fairy Variants|Shogun|Pieces promote and can be dropped, similar to Shogi.|
+hoppelpoppel|Fairy Variants|Hoppel-Poppel|Knights capture as bishops; bishops capture as knights.|http://www.chessvariants.com/diffmove.dir/hoppel-poppel.html
+amazon|Fairy Variants|Amazon|Replace the Queen with Amazon (Q + N).|https://www.chessvariants.com/diffmove.dir/amazone.html
+gothic|Fairy Variants|Gothic Chess|Gothic chess. Capablanca chess with better starting position.|https://www.chessvariants.com/large.dir/gothicchess.html
+chaturanga|Fairy Variants|Chaturanga|Ancient form of chess. Pawns, bishops(elephants), and queen(ferz) are different from the ones in modern chess.|https://en.wikipedia.org/wiki/Chaturanga
+chak|Fairy Variants|Chak|Mayan chess. Inspired by cultural elements of Mesoamerica.|
+chennis|Fairy Variants|Chennis|Pieces alternate between two forms with each move.|
+mansindam|Fairy Variants|Mansindam|A variant that combines the Shogi's drop rule with strong pieces.|
+wolf|Fairy Variants|Wolf Chess|Play with the hybrid pieces, Fox (B+N) , Wolf (R+N), Nightrider (N0) and Sergeant (fKifmnD) on a 8x10 board.|https://en.wikipedia.org/wiki/Wolf_chess
+dragon|Fairy Variants|Dragon Chess|A Dragon (B+N) can be dropped at the 1st rank.|https://www.edami.com/dragonchess/
+almost|Fairy Variants|Almost Chess|Replace the Queen with Chancellor (R + N).|https://en.wikipedia.org/wiki/Almost_chess
+chigorin|Fairy Variants|Chigorin Chess|Chancellor (R + N) and Knights versus Queen and Bishops. Pawns can promote to anything except king that was in the player's army at the start of the game.|https://www.chessvariants.com/diffsetup.dir/chigorin.html
+nightrider|Fairy Variants|Nightrider Chess|A fairy chess piece called Nightrider (N0) that can move any number of steps as a knight in the same direction replaces the knights.|https://en.wikipedia.org/wiki/Nightrider_(chess)
+grasshopper|Fairy Variants|Grasshopper Chess|The grasshopper (gQ) must hop over other pieces to the square behind that piece in 8 directions in order to move or capture.|https://en.wikipedia.org/wiki/Grasshopper_chess
+omicron|Fairy Variants|Omicron Chess|Omega chess on 12x10 board. Champion (WAD) and Wizard (FC) are introduced.|http://www.eglebbk.dds.nl/program/chess-omicron.html
+gustav3|Fairy Variants|Gustav III's Chess|Four extra corners on a 10x8 board are initially positioned two General-Adjutants (Q + N).|https://www.chessvariants.com/play/gustav-iiis-chess
+berolina|Fairy Variants|Berolina Chess|Pawns capture a square orthogonally forward and move one square diagonally forward. They can also double step diagonally when not moved.|https://en.wikipedia.org/wiki/Berolina_pawn#Berolina_chess
+centaur|Fairy Variants|Royal Court|Crowned Knights (K + N) are added to the 10x8 board.|https://www.chessvariants.com/large.dir/contest/royalcourt.html
+tencubed|Fairy Variants|TenCubed Chess|Marshall (R + N), Archbishop (B + N), Champion (WAD) and Wizard (CZ) are added on a 10x10 board. No castling.|https://www.chessvariants.com/contests/10/tencubedchess.html
+shatranj|Fairy Variants|Shatranj|An old form of chess originating from chaturanga, as played in the Sasanian Empire.|https://en.wikipedia.org/wiki/Shatranj
+shatar|Fairy Variants|Shatar|Chess played in Mongolia with some special rules. See the wiki in <Variant INFO> for more details.|https://en.wikipedia.org/wiki/Shatar
+courier|Fairy Variants|Courier Chess|A chess variant that dates from the 12th century and was popular for at least 600 years. Schleich (W) and Courier (B) are added while bishop moves and queen moves are different from modern ones.|https://en.wikipedia.org/wiki/Courier_chess
+raazuvaa|Fairy Variants|Raazuvaa|Maldivian Chess. Classical Shatranj with modern Bishop and Queen moves and Kings crosswise.|https://www.researchgate.net/publication/374859315_Maldivian_Chess_Raazuvaa
+newzealand|Fairy Variants|New Zealand|Knights capture like rooks and vice versa.|
+embassy|Fairy Variants|Embassy Chess|Grand Chess on a 10x8 board and the rules are the same with Capablanca Chess.|https://en.wikipedia.org/wiki/Grand_Chess#Embassy_chess
+opulent|Fairy Variants|Opulent Chess|A decimal chess variant similar to Grand Chess, but with a stronger Knight (WN), and two new jumping pieces Lion (FC) and Wizard (HFD).|https://www.chessvariants.com/rules/opulent-chess
+caparandom|Fairy Variants|Capablance Chess 960|Capablance Chess with Fischer Random (Chess 960) rules applied.|
+paradigm|Fairy Variants|Paradigm Chess 30|8x8 variant with a bishop+horse hybrid piece replacing bishops.|https://www.chessvariants.com/rules/paradigm-chess30
+sortofalmost|Fairy Variants|Sort Of Almost Chess|One queen is replaced by a Chancellor.|https://en.wikipedia.org/wiki/Almost_chess#Sort_of_almost_chess
+chancellor|Fairy Variants|Chancellor Chess|9x9 variant with Chancellors.|https://en.wikipedia.org/wiki/Chancellor_chess
+janus|Fairy Variants|Janus Chess|10x8 variant with two archbishops per side.|https://en.wikipedia.org/wiki/Janus_Chess
+modern|Fairy Variants|Modern Chess|9x9 variant with archbishops.|https://en.wikipedia.org/wiki/Modern_chess
+perfect|Fairy Variants|Perfect Chess|General (Q + N), Chancellor (R + N) and Minister (B + N) are added to the game.|https://www.chessvariants.com/diffmove.dir/perfectchess.html
 
-orda|Army Variants|Orda Chess|Asymmetric variant where one army has pieces that move like knights but capture differently.
-synochess|Army Variants|Syno Chess|Asymmetric East vs. West variant which pits the western Chess army against a Xiangqi and Janggi-styled army.
-shinobiplus|Army Variants|Shinobi+|Asymmetric variant which pits the western Chess army against a drop-based, Shogi-styled army.
-empire|Army Variants|Empire Chess|Asymmetric variant where one army has pieces that move like queens but capture as usual.
-ordamirror|Army Variants|Orda Mirror|Orda Chess variant with two Horde armies. The Falcon replaces the Yurt.
-spartan|Army Variants|Spartan|Asymmetric Spartans vs. Persians variant.
-horde|Army Variants|Horde|Lots of pawns VS chess army. White wins when checkmating black while black wins when capturing all white pieces.
-khans|Army Variants|Khans Chess|Orda Chess variant. The scout and khatun replaces the pawn and yurt.
+orda|Army Variants|Orda Chess|Asymmetric variant where one army has pieces that move like knights but capture differently.|
+synochess|Army Variants|Syno Chess|Asymmetric East vs. West variant which pits the western Chess army against a Xiangqi and Janggi-styled army.|
+shinobiplus|Army Variants|Shinobi+|Asymmetric variant which pits the western Chess army against a drop-based, Shogi-styled army.|
+empire|Army Variants|Empire Chess|Asymmetric variant where one army has pieces that move like queens but capture as usual.|
+ordamirror|Army Variants|Orda Mirror|Orda Chess variant with two Horde armies. The Falcon replaces the Yurt.|
+spartan|Army Variants|Spartan|Asymmetric Spartans vs. Persians variant.|https://www.chessvariants.com/rules/spartan-chess
+horde|Army Variants|Horde|Lots of pawns VS chess army. White wins when checkmating black while black wins when capturing all white pieces.|https://en.wikipedia.org/wiki/Dunsany%27s_Chess#Horde_Chess
+khans|Army Variants|Khans Chess|Orda Chess variant. The scout and khatun replaces the pawn and yurt.|
 
-ataxx|Rule Variants|ATAXX|Infection game. Pieces can turn the enemy pieces in the 8 squares around the destination square into friendly pieces after move.
-snailtrail|Rule Variants|Snail Trail|The squares that pieces have moved from will be blocked. The one who gets stuck loses.
+ataxx|Rule Variants|ATAXX|Infection game. Pieces can turn the enemy pieces in the 8 squares around the destination square into friendly pieces after move.|https://en.wikipedia.org/wiki/Ataxx
+amazons|Rule Variants|Game of the Amazons|Move queens and place a wall on squares in the 8 directions from the destination square. The last player able to move is the winner.|https://en.wikipedia.org/wiki/Game_of_the_Amazons
+breakthrough|Rule Variants|Breakthrough|The first player to reach the farthest rank by moving the piece (mfWfF) is the winner.|https://en.wikipedia.org/wiki/Breakthrough_(board_game)
+clobber|Rule Variants|Clobber|Players take turns to capture an opponent piece which is orthogonally adjacent to their own pieces. The one who cannot move loses.|https://en.wikipedia.org/wiki/Clobber
+cfour|Rule Variants|Connect Four|Be the first to form a horizontal, vertical, or diagonal line of four of one's own tokens to win.|https://en.wikipedia.org/wiki/Connect_Four
+tictactoe|Rule Variants|Tic-tac-toe|Noughts and Crosses. The player who succeeds in placing three of their marks in a horizontal, vertical, or diagonal row is the winner.|https://en.wikipedia.org/wiki/Tic-tac-toe
+flipersi|Rule Variants|Reversi|Drop your disk on a square that can enclose opponent disks lie in a straight line to turn those opponent disks color into yours. The one having more disks of that one's color wins when no moves are available.|https://en.wikipedia.org/wiki/Reversi
+flipello|Rule Variants|Othello|Reversi but players can pass their turn when they have no legal moves and the board has empty squares left.|https://en.wikipedia.org/wiki/Reversi#Othello
+fox-and-hounds|Rule Variants|Fox and Hounds|Hounds (fF) hunting the fox (F). If fox has no moves available, hounds wins. If fox reaches the farthest rank, fox wins.|https://boardgamegeek.com/boardgame/148180/fox-and-hounds
+isolation|Rule Variants|Isolation|Players move their piece (K) and then place a wall square. The one who cannot move loses.|https://boardgamegeek.com/boardgame/1875/isolation
+joust|Rule Variants|Joust|The squares that pieces (N) have moved from will be blocked. The one who cannot move loses.|https://www.chessvariants.com/programs.dir/joust.html
+snailtrail|Rule Variants|Snail Trail|The squares that pieces (K) have moved from will be blocked. The one who cannot move loses.|https://boardgamegeek.com/boardgame/37135/snailtrail
+clobber10|Rule Variants|Clobber 10x10|Clobber on a 10x10 board, mainly played by computers|
+flipello10|Rule Variants|Reversi 10x10|Othello on a 10x10 board, mainly played by computers|
+isolation7x7|Rule Variants|Isolation 7x7|7x7 version of Isolation.|
 
+bughouse|(not supported)|Bughouse Chess|Team work chess where 4 players play on 2 boards in teams of 2. Captured pieces on one board are passed on to the teammate on the other board, who then has the option of dropping these pieces on their board.|https://en.wikipedia.org/wiki/Bughouse_chess
+koedem|(not supported)|Koedem|Bughouse Chess but kings can be captured and then immediately given to teammate whose next move has to play that king. The team has all four kings wins.|http://schachclub-oetigheim.de/wp-content/uploads/2016/04/Koedem-rules.pdf
+
+fairy|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for endgame initialization.|
+mini|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for internal purposes.|
+normal|Pesudo Variants|♔♕♖♗♘♙♚♛♜♝♞♟|Pseudo-variant only used for internal purposes.|

--- a/src/main.js
+++ b/src/main.js
@@ -966,6 +966,7 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
             let tmpboard = new ffish.Board(variant, startfen, is960);
             let moveslist = ucimoves.split(/[ ]+/).reverse();
             let result = "";
+            let tmpboardresult = "";
             if (moveslist.length == 1 && moveslist[0] == "") {
             } else {
               while (moveslist.length > 0) {
@@ -974,52 +975,63 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
                 }
               }
             }
+            tmpboardresult = tmpboard.result();
             if (notation == "DEFAULT") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(ucimoves, ffish.Notation.DEFAULT);
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.DEFAULT) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "SAN") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(ucimoves, ffish.Notation.SAN);
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.SAN) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "LAN") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(ucimoves, ffish.Notation.LAN);
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.LAN) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "SHOGI_HOSKING") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(
-                ucimoves,
-                ffish.Notation.SHOGI_HOSKING,
-              );
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.SHOGI_HOSKING) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "SHOGI_HODGES") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(
-                ucimoves,
-                ffish.Notation.SHOGI_HODGES,
-              );
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.SHOGI_HODGES) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "SHOGI_HODGES_NUMBER") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(
-                ucimoves,
-                ffish.Notation.SHOGI_HODGES_NUMBER,
-              );
+              result =
+                tmpboard.variationSan(
+                  ucimoves,
+                  ffish.Notation.SHOGI_HODGES_NUMBER,
+                ) + (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "JANGGI") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(ucimoves, ffish.Notation.JANGGI);
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.JANGGI) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "XIANGQI_WXF") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(
-                ucimoves,
-                ffish.Notation.XIANGQI_WXF,
-              );
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.XIANGQI_WXF) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "THAI_SAN") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(ucimoves, ffish.Notation.THAI_SAN);
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.THAI_SAN) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "THAI_LAN") {
               tmpboard.setFen(startfen);
-              return tmpboard.variationSan(ucimoves, ffish.Notation.THAI_LAN);
+              result =
+                tmpboard.variationSan(ucimoves, ffish.Notation.THAI_LAN) +
+                (tmpboardresult !== "*" ? " " + tmpboardresult : "");
             } else if (notation == "FEN") {
-              return tmpboard.fen();
+              result = tmpboard.fen();
             } else if (notation == "PGN") {
-              const gameresult = tmpboard.result();
+              const gameresult = tmpboardresult;
               tmpboard.setFen(startfen);
               const today = new Date();
               const year = today.getFullYear();
@@ -1052,7 +1064,6 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
               result += `[Round "1"]\n[White "${whitename}"]\n[Black "${blackname}"]\n`;
               result += `[FEN "${startfen}"]\n[Result "${gameresult}"]\n[Variant "${tmpboard.variant()}"]\n\n`;
               result += tmpboard.variationSan(ucimoves, ffish.Notation.SAN);
-              return result;
             } else if (notation == "EPD") {
               const today = new Date();
               const year = today.getFullYear();
@@ -1109,13 +1120,12 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
               result += ` variant "${tmpboard.variant()}";`;
               result += ` site "${window.location.host}";`;
               result += ` date "${year.toString() + "." + month.toString() + "." + day.toString()}";`;
-              result += ` result "${tmpboard.result()}";`;
+              result += ` result "${tmpboardresult}";`;
               result += ` first_player "${whitename}";`;
               result += ` second_player "${blackname}";`;
-              return result;
             } else if (notation == "FEN+UCIMOVE") {
               tmpboard.setFen(startfen);
-              return tmpboard.fen() + "|" + ucimoves;
+              result = tmpboard.fen() + "|" + ucimoves;
             } else if (notation == "FEN+USIMOVE") {
               tmpboard.setFen(startfen);
               let dimensions = getDimensions();
@@ -1125,12 +1135,11 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
                 dimensions.height,
               );
               if (convertedmoves != null) {
-                return tmpboard.fen() + "|" + convertedmoves;
+                result = tmpboard.fen() + "|" + convertedmoves;
               } else {
-                return (
+                result =
                   tmpboard.fen() +
-                  "|(There are moves that cannot be displayed in USI moves, such as pawn promotion or seirawan gating)"
-                );
+                  "|(There are moves that cannot be displayed in USI moves, such as pawn promotion or seirawan gating)";
               }
             } else if (notation == "FEN+UCCIMOVE") {
               tmpboard.setFen(startfen);
@@ -1141,12 +1150,11 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
                 dimensions.height,
               );
               if (convertedmoves != null) {
-                return tmpboard.fen() + "|" + convertedmoves;
+                result = tmpboard.fen() + "|" + convertedmoves;
               } else {
-                return (
+                result =
                   tmpboard.fen() +
-                  "|(There are moves that cannot be displayed in UCCI moves, such as pawn promotion or seirawan gating)"
-                );
+                  "|(There are moves that cannot be displayed in UCCI moves, such as pawn promotion or seirawan gating)";
               }
             } else if (notation == "SFEN+USIMOVE") {
               tmpboard.setFen(startfen);
@@ -1157,23 +1165,22 @@ function getNotation(notation, variant, startfen, is960, ucimovestr) {
                 dimensions.height,
               );
               if (convertedmoves != null) {
-                return (
+                result =
                   fge.ConvertFENtoSFEN(tmpboard.fen()) +
                   "|" +
                   fge.convertUCImovestoUSImoves(
                     ucimoves,
                     dimensions.width,
                     dimensions.height,
-                  )
-                );
+                  );
               } else {
-                return (
+                result =
                   fge.ConvertFENtoSFEN(tmpboard.fen()) +
-                  "|(There are moves that cannot be displayed in USI moves, such as pawn promotion or seirawan gating)"
-                );
+                  "|(There are moves that cannot be displayed in USI moves, such as pawn promotion or seirawan gating)";
               }
             }
             tmpboard.delete();
+            return result;
           } else {
             return "Illegal FEN";
           }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-// ffish.js test using chessgroundx
+﻿// ffish.js test using chessgroundx
 const Chessground = require("chessgroundx").Chessground;
 import * as util from "chessgroundx/util";
 const variantsIni = document.getElementById("variants-ini");
@@ -33,6 +33,8 @@ const buttonSpecifiedPosition = document.getElementById("specifiedposition");
 const buttonGameStart = document.getElementById("gamestart");
 const playWhite = document.getElementById("playwhite");
 const playBlack = document.getElementById("playblack");
+const randomMoverWhite = document.getElementById("randommoverwhite");
+const randomMoverBlack = document.getElementById("randommoverblack");
 const currentBoardFen = document.getElementById("currentboardfen");
 const gameResult = document.getElementById("gameresult");
 const gameStatus = document.getElementById("gamestatus");
@@ -94,6 +96,7 @@ const buttonmakemove = document.getElementById("makemove");
 const buttonhighlightmove = document.getElementById("highlightmove");
 const searchresultinfo = document.getElementById("searchresultinfo");
 const dropdownNotationSystem = document.getElementById("sannotation");
+const pRandomMoverGo = document.getElementById("randommovergo");
 const soundMove = new Audio("assets/sound/thearst3rd/move.wav");
 const soundCapture = new Audio("assets/sound/thearst3rd/capture.wav");
 const soundCheck = new Audio("assets/sound/thearst3rd/check.wav");
@@ -1369,12 +1372,20 @@ new Module().then((loadedModule) => {
   };
 
   buttonGameStart.onclick = function () {
-    if (playWhite.checked == true && playBlack.checked == false) {
+    if (
+      (playWhite.checked == true || randomMoverWhite.checked == true) &&
+      playBlack.checked == false &&
+      randomMoverBlack.checked == false
+    ) {
       chessground.set({
         orientation: "black",
       });
     }
-    if (playWhite.checked == false && playBlack.checked == true) {
+    if (
+      playWhite.checked == false &&
+      randomMoverWhite.checked == false &&
+      (playBlack.checked == true || randomMoverBlack.checked == true)
+    ) {
       chessground.set({
         orientation: "white",
       });
@@ -2285,6 +2296,14 @@ new Module().then((loadedModule) => {
     if (labelPgn) {
       labelPgn.innerText = getPgn(board);
     }
+  };
+
+  pRandomMoverGo.onclick = function () {
+    let movelist = textMoves.value.trim().split(/[ ]+/);
+    let legalmoves = board.legalMoves().trim().split(/[ ]+/);
+    movelist.push(legalmoves[Math.floor(Math.random() * legalmoves.length)]);
+    textMoves.value = movelist.join(" ");
+    pSetFen.click();
   };
 
   updateChessground();


### PR DESCRIPTION
After this change:
1. Added wiki page link feature for \<Variant INFO\>
2. Added variant description & wiki page link for all built in variants. If there is a wiki page, the dialog will show the link and ask whether the user want to go to the wiki page.
3. Added theme for Supply Chess, Makruk House and Janggi House.
4. Fixed memory leak in `getNotation()` and added result display for SAN moves.
5. Added Random Mover feature.