### PR TITLE
Upload artifacts after build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,28 +16,28 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows-x86_64
+          name: Fairyground-Windows-x86_64
           path: ./release_make/artifacts/Windows-x86_64.zip
           compression-level: 0
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Windows-ARM64
+          name: Fairyground-Windows-ARM64
           path: ./release_make/artifacts/Windows-ARM64.zip
           compression-level: 0
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Linux-x86_64
+          name: Fairyground-Linux-x86_64
           path: ./release_make/artifacts/Linux-x86_64.zip
           compression-level: 0
           if-no-files-found: error
 
       - uses: actions/upload-artifact@v4
         with:
-          name: Linux-ARM64
+          name: Fairyground-Linux-ARM64
           path: ./release_make/artifacts/Linux-ARM64.zip
           compression-level: 0
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,3 +13,31 @@ jobs:
       - uses: actions/checkout@v4
       - run: chmod 744 ./release_make/CI.sh
       - run: ./release_make/CI.sh
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-x86_64
+          path: ./release_make/artifacts/Windows-x86_64.zip
+          compression-level: 0
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Windows-ARM64
+          path: ./release_make/artifacts/Windows-ARM64.zip
+          compression-level: 0
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Linux-x86_64
+          path: ./release_make/artifacts/Linux-x86_64.zip
+          compression-level: 0
+          if-no-files-found: error
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Linux-ARM64
+          path: ./release_make/artifacts/Linux-ARM64.zip
+          compression-level: 0
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ You can see it deployed at: [https://fairyground.vercel.app/](https://fairygroun
 
 ## Usage
 
+The following steps (_**Installation**_ and _**Run Application**_) show the process to install a development environment.
+
+If you want a one-click-to-run version, you can download the executables in the [Latest Build Actions](https://github.com/ianfab/fairyground/actions/workflows/ci.yml) section. (requires logging in to github)
+
 ### ◎ Installation
 
 #### ⊙ Prerequisites

--- a/release_make/CI.sh
+++ b/release_make/CI.sh
@@ -107,10 +107,10 @@ echo "[Info] Compressing & packing artifacts to prepare for uploading..."
 cd ./release_make
 mkdir artifacts
 
-zip -9 -r ./artifacts/Windows-x86_64.zip ./release-builds/win/x64 || Error
-zip -9 -r ./artifacts/Windows-ARM64.zip ./release-builds/win/arm64 || Error
-zip -9 -r ./artifacts/Linux-x86_64.zip ./release-builds/linux/x64 || Error
-zip -9 -r ./artifacts/Linux-ARM64.zip ./release-builds/linux/arm64 || Error
+zip -9 -q -r ./artifacts/Windows-x86_64.zip ./release-builds/win/x64 || Error
+zip -9 -q -r ./artifacts/Windows-ARM64.zip ./release-builds/win/arm64 || Error
+zip -9 -q -r ./artifacts/Linux-x86_64.zip ./release-builds/linux/x64 || Error
+zip -9 -q -r ./artifacts/Linux-ARM64.zip ./release-builds/linux/arm64 || Error
 
 echo "[Info] Artifacts packed. Pending for upload..."
 exit 0

--- a/release_make/CI.sh
+++ b/release_make/CI.sh
@@ -102,4 +102,15 @@ echo "[Warning] The macOS executables are not suitably signed yet. If you want t
 echo "[Warning] Use codesign on macOS to sign your executable. If you don't have a Mac, you can use a virtual machine."
 echo "[Warning] If you want to build a macOS virtual machine, please visit https://www.sysnettechsolutions.com/en/install-macos-vmware/"
 echo "[Info] CI build test OK."
+echo "[Info] Compressing & packing artifacts to prepare for uploading..."
+
+cd ./release_make
+md artifacts
+
+zip -9 -r ./artifacts/Windows-x86_64.zip ./release-builds/win/x64 || Error
+zip -9 -r ./artifacts/Windows-ARM64.zip ./release-builds/win/arm64 || Error
+zip -9 -r ./artifacts/Linux-x86_64.zip ./release-builds/linux/x64 || Error
+zip -9 -r ./artifacts/Linux-ARM64.zip ./release-builds/linux/arm64 || Error
+
+echo "[Info] Artifacts packed. Pending for upload..."
 exit 0

--- a/release_make/CI.sh
+++ b/release_make/CI.sh
@@ -105,7 +105,7 @@ echo "[Info] CI build test OK."
 echo "[Info] Compressing & packing artifacts to prepare for uploading..."
 
 cd ./release_make
-md artifacts
+mkdir artifacts
 
 zip -9 -r ./artifacts/Windows-x86_64.zip ./release-builds/win/x64 || Error
 zip -9 -r ./artifacts/Windows-ARM64.zip ./release-builds/win/arm64 || Error


### PR DESCRIPTION
After this change, the executables built for Windows and Linux will be uploaded. Users can download these executables from the Actions section.