### PR TITLE
Add NoaChess: Custom 6×6 chess variant

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "fairyground",
+  "name": "NoaChess",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,8 +8,8 @@
       "dependencies": {
         "chessgroundx": "^10.6.3",
         "express": "^4.18.2",
-        "fairy-stockfish-nnue.wasm": "^1.1.9",
-        "ffish-es6": "^0.7.7",
+        "fairy-stockfish-nnue.wasm": "1.1.9",
+        "ffish-es6": "0.7.7",
         "gif.js": "^0.2.0",
         "jszip": "^3.10.1",
         "mithril": "^2.2.2",
@@ -3384,9 +3384,10 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
     "node_modules/fairy-stockfish-nnue.wasm": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/fairy-stockfish-nnue.wasm/-/fairy-stockfish-nnue.wasm-1.1.10.tgz",
-      "integrity": "sha512-yxeRxyfYKsDbAEKUbcc0qepH+clk0NaH1tCMcvkkX1iGBvub9UbZIFIVLhh4XysiLBatOJaSTUrzyqVkKOVx6A=="
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fairy-stockfish-nnue.wasm/-/fairy-stockfish-nnue.wasm-1.1.9.tgz",
+      "integrity": "sha512-vWirUkTzj3nboBxTZTKgBgv/eW8ATKQi2OmJvZF7UIbkrSrqly0qN7MI4oVUuClD7fXscVu9Umv9vP+CA8tPxA==",
+      "license": "GPL-3.0"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3441,9 +3442,10 @@
       }
     },
     "node_modules/ffish-es6": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/ffish-es6/-/ffish-es6-0.7.8.tgz",
-      "integrity": "sha512-uSSYUE6peqftzbAMuIBl1EMTVlwr0hwi/Gw3xyIdgo3BlwXMezXhP/kZ73pWnoNxem1tf3pon2QYKlsBmbGCiw=="
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/ffish-es6/-/ffish-es6-0.7.7.tgz",
+      "integrity": "sha512-XSKZDq8ioM6f4/Qhk2XqxlCpxh6avWHUnvsh/0+QStoMjiKHLrG0+P18WJ1HKlLhLf8KgIxYI0law8WjH/XRtA==",
+      "license": "GPL-3.0"
     },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",

--- a/public/noachess.ini
+++ b/public/noachess.ini
@@ -1,0 +1,52 @@
+# NoaChess - Custom 6×6 Chess Variant
+# Created for NoaChess project
+
+[noachess]
+# Board dimensions
+maxRank = 6
+maxFile = 6
+
+# Piece character mapping
+# L/l = Leaper, B/b = Bishop, Q/q = Queen, K/k = King, N/n = Knight, R/r = Rook
+# P/p = Pawn, G/g = General (promoted pawn)
+pieceToCharTable = PNBRQL.G.........Kpnbrql.g.........k
+
+# Standard pieces
+knight = n
+king = k
+
+# Custom pieces with Betza notation
+# Pawn: moves forward/sideways, captures forward diagonally
+customPiece1 = p:fsmWfcF
+# Bishop: moves 1 square diagonally OR jumps 2 squares orthogonally
+customPiece2 = b:FD
+# Rook: moves up to 4 squares orthogonally
+customPiece3 = r:mR4cR4
+# Queen: moves up to 4 squares in any direction
+customPiece4 = q:mQ4cQ4
+# Leaper: moves and captures 1 square in any direction, additionally captures by jumping 2 squares
+customPiece5 = l:mWFcWFcAD
+# General: moves 1 square in any direction (like King but not royal)
+customPiece6 = g:WF
+
+# Starting position
+# Rank 6 (black): lbqknr
+# Rank 5 (black pawns): pppppp
+# Ranks 4-3: empty
+# Rank 2 (white pawns): PPPPPP
+# Rank 1 (white): LBQKNR
+startFen = lbqknr/pppppp/6/6/PPPPPP/LBQKNR w - - 0 1
+
+# Promotion rules
+promotionRegionWhite = *6
+promotionRegionBlack = *1
+promotionPieceTypes = g
+promotedPieceType = g
+
+# Disable standard chess rules
+doubleStep = false
+castling = false
+enPassant = false
+
+# Game rules
+stalemateValue = loss

--- a/public/themes.txt
+++ b/public/themes.txt
@@ -75,6 +75,8 @@
 *|meridaletters,cburnettletters,lettertiles,letters,blindfold,userdefined|
 |merida,cburnett|blueboard,greenboard,brownboard,purpleboard,cobaltboard
 
+noachess||brownboard
+
 seirawan|seirawan|
 shouse|@seirawan|
 duck|duck|

--- a/public/variantsettings.txt
+++ b/public/variantsettings.txt
@@ -6,6 +6,9 @@
 #The wiki page will be shown when users click <Variant INFO> button and click <Yes> or <OK>.
 #This can also be accessed from <Variant INFO> button.
 
+# NoaChess: Custom 6×6 variant with unique pieces
+noachess|Chess Variants|NoaChess|6×6 chess variant with unique piece movements. Pawns promote to Generals.|
+
 # Chess Variants: Variants based on Chess and do not introduce fairy pieces
 chess|Chess Variants|Chess|Chess, unmodified, as it's played by FIDE standards.|https://en.wikipedia.org/wiki/Chess
 fischerandom|Chess Variants|Fischer Random|Chess960. Pieces at the 1st/8th rank can be placed randomly but the bishops must be on squares of different colors and the king must be between the rooks. Special castling rules are applied.|https://en.wikipedia.org/wiki/Fischer_random_chess

--- a/src/html/advanced.html
+++ b/src/html/advanced.html
@@ -1,7 +1,7 @@
 ﻿<!doctype html>
 <head>
   <meta charset="utf-8" />
-  <title>Fairy-Stockfish playground</title>
+  <title>NoaChess</title>
   <!-- By curl https://data-url-maker-hiro18181.netlify.app/api/url/https://upload.wikimedia.org/wikipedia/commons/e/ef/Chess_ndt45.svg -->
   <link
     rel="icon"
@@ -7100,6 +7100,8 @@
               disabled: !is_ready || analysis_mode,
               min: 1,
               max: 255,
+              value: 12,
+              readonly: true,
             }),
             m("input[type=number]#movetime", {
               placeholder: "Movetime",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -3791,6 +3791,18 @@ new Module().then((loadedModule) => {
   ffish = loadedModule;
   console.log("ffish.js initialized!");
   window.ffishlib = loadedModule; //Used in dev tools for debugging purposes and transfer to <script>
+
+  // Load NoaChess variant
+  fetch('./noachess.ini')
+    .then(response => response.text())
+    .then(ini => {
+      ffish.loadVariantConfig(ini);
+      console.log("NoaChess variant loaded successfully!");
+    })
+    .catch(error => {
+      console.error("Failed to load NoaChess variant:", error);
+    });
+
   initBoard(dropdownVariant.value);
   soundMove.volume = rangeVolume.value;
   soundCapture.volume = rangeVolume.value;


### PR DESCRIPTION
- Add NoaChess variant definition with unique piece movements
  - Pawn: moves forward/sideways, captures diagonally forward, promotes to General
  - Bishop: moves 1 diagonal OR jumps 2 orthogonal
  - Rook: moves up to 4 squares orthogonally
  - Queen: moves up to 4 squares in any direction
  - Leaper: moves 1 square any direction, captures by jumping 2 squares
  - Knight: standard knight movement
  - King: standard king (royal)
  - General: moves 1 square any direction (non-royal, promoted pawn)

- Update UI:
  - Change title to "NoaChess"
  - Set AI depth to 12 (fixed/readonly)
  - Set default board theme to brownboard
  - White background by default with dark mode toggle available

- Add variant configuration:
  - 6×6 board size
  - Starting position: LBQKNR (both sides mirror each other)
  - No castling, no double-step, no en passant
  - Pawns promote to General on reaching opposite end